### PR TITLE
In discrete steps, Simplify the API

### DIFF
--- a/opentracing/src/main/java/opentracing/Span.java
+++ b/opentracing/src/main/java/opentracing/Span.java
@@ -13,7 +13,7 @@
  */
 package opentracing;
 
-import java.util.Formatter;
+import java.util.Map;
 
 /**
  * Span represents an active, un-finished span in the opentracing system.
@@ -56,29 +56,7 @@ public interface Span {
   Span setTag(String key, Number value);
 
   /**
-   * {@code message} is a format string and can refer to fields in the payload by path, like so:
-   *
-   * <pre>{@code
-   *
-   * span.info("first transaction is worth ${transactions[0].amount} ${transactions[0].currency}",
-   *     ImmutableMap.of(
-   *       "transactions", asList(
-   *         Transaction.builder().amount(10).currency("USD").build(),
-   *         Transaction.builder().amount(11).currency("USD").build(),
-   *       )
-   *     )
-   * );
-   * }</pre>
-   *
-   * @param message {@link Formatter format string} that can refer to fields in the args payload.
-   * @param args arbitrary payload
-   */
-  // See https://github.com/opentracing/opentracing.github.io/issues/30 about parameterization
-  Span info(String message, Object... args);
-
-  /** Same as {@link #info}, but for warnings. */
-  Span warning(String message, Object... args);
-
-  /** Same as {@link #info}, but for errors. */
-  Span error(String message, Object... args);
+   * @todo
+   **/
+  Span event(String message, Map<String,String> payload);
 }

--- a/opentracing/src/main/java/opentracing/Span.java
+++ b/opentracing/src/main/java/opentracing/Span.java
@@ -28,15 +28,6 @@ public interface Span {
   SpanContext childContext();
 
   /**
-   * Denotes the beginning of a subordinate unit of work.
-   *
-   * @param operationName name of the operation represened by the new span from the perspective of
-   * the current service.
-   * @return a new child Span in "started" state.
-   */
-  Span startChild(String operationName);
-
-  /**
    * Sets the end timestamp and records the span.
    *
    * <p>This should be the last call made to any span instance, and to do otherwise leads to

--- a/opentracing/src/main/java/opentracing/Span.java
+++ b/opentracing/src/main/java/opentracing/Span.java
@@ -25,7 +25,7 @@ public interface Span {
   /**
    * Suitable for serializing over the wire, etc.
    */
-  TraceContext traceContext();
+  SpanContext childContext();
 
   /**
    * Denotes the beginning of a subordinate unit of work.

--- a/opentracing/src/main/java/opentracing/SpanContext.java
+++ b/opentracing/src/main/java/opentracing/SpanContext.java
@@ -14,23 +14,23 @@
 package opentracing;
 
 /**
- * TraceContext encpasulates the smallest amount of state needed to describe a Span's identity
- * within a larger [potentially distributed] trace. The TraceContext is not intended to encode the
+ * SpanContext encpasulates the smallest amount of state needed to describe a Span's identity
+ * within a larger [potentially distributed] trace. The SpanContext is not intended to encode the
  * span's operation name, timing, or log data, but merely any unique identifiers (etc) needed to
  * contextualize it within a larger trace tree.
  *
- * <p>TraceContexts are sufficient to propagate the, well, *context* of a particular trace between
+ * <p>SpanContexts are sufficient to propagate the, well, *context* of a particular trace between
  * processes.
  *
- * <p>TraceContext also support a simple string map of "trace attributes". These trace attributes
+ * <p>SpanContext also support a simple string map of "trace attributes". These trace attributes
  * are special in that they are propagated *in-band*, presumably alongside application data. See the
  * documentation for {@link #setAttribute(String, String)} for more details and some important
  * caveats.
  */
-public interface TraceContext {
+public interface SpanContext {
 
   /**
-   * Sets a tag on this TraceContext that also propagates to future children per {@link
+   * Sets a tag on this SpanContext that also propagates to future children per {@link
    * TraceContextSource#newChild(TraceContext)}.
    *
    * <p>Trace attributes enables powerful functionality given a full-stack opentracing integration
@@ -54,7 +54,7 @@ public interface TraceContext {
    * must be letters, numbers, or hyphens. undefined behavior results if the `restrictedKey` does
    * not meet these criteria.
    */
-  TraceContext setAttribute(String restrictedKey, String value);
+  SpanContext setAttribute(String restrictedKey, String value);
 
   /**
    * Gets the value for a trace tag given its key. Returns Null if the value isn't found in this

--- a/opentracing/src/main/java/opentracing/TraceCodec.java
+++ b/opentracing/src/main/java/opentracing/TraceCodec.java
@@ -16,7 +16,7 @@ package opentracing;
 import java.util.Map;
 
 /**
- * Encodes or Decodes a {@link SpanContext trace context} in binary or text formats.
+ * Encodes or Decodes a {@link SpanContext context} in binary or text formats.
  *
  * <p>The toXXX methods are expected to serialize trace contexts into a pair of values representing
  * separately the trace context / span identity, and the trace attributes. This is done specifically
@@ -24,7 +24,7 @@ import java.util.Map;
  * binary message format, so that it can be inspected efficiently by the middleware / routing layers
  * without parsing the whole message.
  */
-public interface TraceContextCodec {
+public interface TraceCodec {
 
   /**
    * Implementation-specific format of a span's identity along with any span attributes.

--- a/opentracing/src/main/java/opentracing/TraceContext.java
+++ b/opentracing/src/main/java/opentracing/TraceContext.java
@@ -13,8 +13,6 @@
  */
 package opentracing;
 
-import java.util.Map;
-
 /**
  * Long-lived interface that knows how to create a root {@link SpanContext} and encode/decode
  * any other.
@@ -34,15 +32,4 @@ public interface TraceContext {
    */
   SpanContext newRoot();
 
-  /**
-   * Creates a child context for {@code parent}, and returns both that child's own
-   * TraceContext as well as any Tags that should be added to the child's Span.
-   */
-  ChildTraceContext newChild(SpanContext parent);
-
-  interface ChildTraceContext {
-    SpanContext child();
-
-    Map<String, Object> tags();
-  }
 }

--- a/opentracing/src/main/java/opentracing/TraceContext.java
+++ b/opentracing/src/main/java/opentracing/TraceContext.java
@@ -19,7 +19,7 @@ import java.util.Map;
  * Long-lived interface that knows how to create a root {@link SpanContext} and encode/decode
  * any other.
  */
-public interface TraceContextSource {
+public interface TraceContext {
 
   /**
    * Encodes or Decodes a {@link SpanContext trace context} in binary or text formats.

--- a/opentracing/src/main/java/opentracing/TraceContext.java
+++ b/opentracing/src/main/java/opentracing/TraceContext.java
@@ -24,7 +24,7 @@ public interface TraceContext {
   /**
    * Encodes or Decodes a {@link SpanContext trace context} in binary or text formats.
    */
-  TraceContextCodec codec();
+  TraceCodec codec();
 
   /**
    * Create a SpanContext which has no parent (and thus begins its own trace).

--- a/opentracing/src/main/java/opentracing/TraceContextCodec.java
+++ b/opentracing/src/main/java/opentracing/TraceContextCodec.java
@@ -16,7 +16,7 @@ package opentracing;
 import java.util.Map;
 
 /**
- * Encodes or Decodes a {@linkplain TraceContext trace context} in binary or text formats.
+ * Encodes or Decodes a {@link SpanContext trace context} in binary or text formats.
  *
  * <p>The toXXX methods are expected to serialize trace contexts into a pair of values representing
  * separately the trace context / span identity, and the trace attributes. This is done specifically
@@ -27,13 +27,13 @@ import java.util.Map;
 public interface TraceContextCodec {
 
   /**
-   * Implementation-specific format of a span's identity along with any trace attributes.
+   * Implementation-specific format of a span's identity along with any span attributes.
    *
    * @param <E> encoding, for example {@code byte[]} for binary, or {@code Map<String, String>} for
    * text.
    */
-  // Can instead explicitly create BinaryEncodedTraceContext, TextEncodedTraceContext, just.. cluttery
-  interface EncodedTraceContext<E> {
+  // Can instead explicitly create BinaryEncodedSpanContext, TextEncodedSpanContext, just.. cluttery
+  interface EncodedSpanContext<E> {
     /** Encoded span identifier. */
     E spanIdentity();
 
@@ -42,30 +42,30 @@ public interface TraceContextCodec {
   }
 
   /**
-   * Encodes the trace context into a binary representation of the span's identity and trace
+   * Encodes the span context into a binary representation of the span's identity and trace
    * attributes.
    */
-  EncodedTraceContext<byte[]> toBinary(TraceContext tc);
+  EncodedSpanContext<byte[]> toBinary(SpanContext tc);
 
   /**
-   * Decodes a trace context from a binary representation of the span's identity and trace
+   * Decodes a span context from a binary representation of the span's identity and trace
    * attributes.
    *
    * @throws IllegalArgumentException if the encoded data is malformed.
    */
-  TraceContext fromBinary(EncodedTraceContext<byte[]> encoded);
+  SpanContext fromBinary(EncodedSpanContext<byte[]> encoded);
 
   /**
-   * Encodes the trace context into a text representation of the span's identity and trace
+   * Encodes the span context into a text representation of the span's identity and trace
    * attributes.
    */
-  EncodedTraceContext<Map<String, String>> toText(TraceContext tc);
+  EncodedSpanContext<Map<String, String>> toText(SpanContext tc);
 
   /**
-   * Decodes a trace context from a text representation of the span's identity and trace
+   * Decodes a span context from a text representation of the span's identity and trace
    * attributes.
    *
    * @throws IllegalArgumentException if the encoded data is malformed.
    */
-  TraceContext fromText(EncodedTraceContext<Map<String, String>> encoded);
+  SpanContext fromText(EncodedSpanContext<Map<String, String>> encoded);
 }

--- a/opentracing/src/main/java/opentracing/TraceContextSource.java
+++ b/opentracing/src/main/java/opentracing/TraceContextSource.java
@@ -16,32 +16,32 @@ package opentracing;
 import java.util.Map;
 
 /**
- * Long-lived interface that knows how to create a root {@linkplain TraceContext} and encode/decode
+ * Long-lived interface that knows how to create a root {@link SpanContext} and encode/decode
  * any other.
  */
 public interface TraceContextSource {
 
   /**
-   * Encodes or Decodes a {@linkplain TraceContext trace context} in binary or text formats.
+   * Encodes or Decodes a {@link SpanContext trace context} in binary or text formats.
    */
   TraceContextCodec codec();
 
   /**
-   * Create a TraceContext which has no parent (and thus begins its own trace).
+   * Create a SpanContext which has no parent (and thus begins its own trace).
    *
    * <p>A TraceContextSource must always return the same type in successive calls to
    * NewRootTraceContext().
    */
-  TraceContext newRoot();
+  SpanContext newRoot();
 
   /**
    * Creates a child context for {@code parent}, and returns both that child's own
    * TraceContext as well as any Tags that should be added to the child's Span.
    */
-  ChildTraceContext newChild(TraceContext parent);
+  ChildTraceContext newChild(SpanContext parent);
 
   interface ChildTraceContext {
-    TraceContext child();
+    SpanContext child();
 
     Map<String, Object> tags();
   }

--- a/opentracing/src/main/java/opentracing/Tracer.java
+++ b/opentracing/src/main/java/opentracing/Tracer.java
@@ -36,7 +36,7 @@ public interface Tracer {
   /**
    * Like {@link #startTrace(String)}, but the returned span is made a child of {@code parent}.
    */
-  Span joinTrace(String operationName, TraceContext parent);
+  Span joinTrace(String operationName, SpanContext parent);
 
   /**
    * StartSpanWithContext returns a span with the given {@code operationName} and an association
@@ -50,5 +50,5 @@ public interface Tracer {
    * Span feed = tracer.startTrace("GetFeed");
    * }</pre>
    */
-  Span startSpanWithContext(String operationName, TraceContext context);
+  Span startSpanWithContext(String operationName, SpanContext context);
 }


### PR DESCRIPTION
This PR contains a sequence of commits to simplify the API.

Class renames:
 - TraceContext to SpanContext
 - TraceContextSource to TraceContext
 - TraceContextCodec to TraceCodec

Removing porcelain api:
 - Span.createChild(..)
 - TraceContext.ChildSpanContext
 - logging methods in Span (replaced with `event(message, payload)`).

Look in the individual commits for the rationale to each.

It's clearer to see the value of the changes by looking at the HEAD of the branch rather than evaluating the patch.