### PR TITLE
Make Span Autocloseable

### DIFF
--- a/opentracing/src/main/java/io/opentracing/Span.java
+++ b/opentracing/src/main/java/io/opentracing/Span.java
@@ -18,7 +18,7 @@ package io.opentracing;
  *
  * <p>Spans are created by the {@link Tracer#buildSpan} interface.
  */
-public interface Span {
+public interface Span extends AutoCloseable {
 
   /**
    * Sets the end timestamp and records the span.
@@ -26,7 +26,8 @@ public interface Span {
    * <p>This should be the last call made to any span instance, and to do otherwise leads to
    * undefined behavior.
    */
-  void finish();
+  @Override
+  void close();
 
   /**
    * Set a key:value tag on the Span.

--- a/opentracing/src/main/java/io/opentracing/Span.java
+++ b/opentracing/src/main/java/io/opentracing/Span.java
@@ -28,6 +28,8 @@ public interface Span extends AutoCloseable {
    * <p>This should be the last call made to any span instance, and to do otherwise leads to
    * undefined behavior.
    */
+  void finish();
+  
   @Override
   void close();
 

--- a/opentracing/src/main/java/io/opentracing/Span.java
+++ b/opentracing/src/main/java/io/opentracing/Span.java
@@ -13,6 +13,8 @@
  */
 package io.opentracing;
 
+import java.util.Set;
+
 /**
  * Represents an in-flight span in the opentracing system.
  *
@@ -53,6 +55,14 @@ public interface Span extends AutoCloseable {
    * Returns null if no entry found, or baggage is not supported in the current implementation.
    */
   String getBaggageItem(String key);
+  
+  /**
+   * Useful for acquiring the set of baggage keys so that clients of the Span have the ability
+   * to access the corresponding baggage value.
+   * 
+   * @return {@link Set} of baggage keys
+   */
+  Set<String> getBaggageKeys();
 
   /**
    * Add a new log event to the Span, accepting an event name string and an optional structured payload argument.

--- a/opentracing/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing/src/main/java/io/opentracing/Tracer.java
@@ -93,10 +93,10 @@ public interface Tracer {
       /** Same as {@link Span#setTag(String, Number)}, but for the span being built. */
       SpanBuilder withTag(String key, Number value);
 
-      /** Same as {@link Span#setBaggageItem(String, String)}, but for the span being built. */
+      /** Specify a timestamp of when the Span was started, represented in microseconds since epoch. */
       SpanBuilder withStartTimestamp(long microseconds);
 
-      /** Specify a timestamp of when the Span was started, represented in microseconds since epoch. */
+      /** Same as {@link Span#setBaggageItem(String, String)}, but for the span being built. */
       SpanBuilder withBaggage(String key, String value);
 
       /** Returns the started Span. */

--- a/opentracing/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing/src/main/java/io/opentracing/Tracer.java
@@ -87,14 +87,17 @@ public interface Tracer {
       /** Same as {@link Span#setTag(String, String)}, but for the span being built. */
       SpanBuilder withTag(String key, String value);
 
-      /** Same as {@link Span#setTag(String, String)}, but for the span being built. */
+      /** Same as {@link Span#setTag(String, boolean)}, but for the span being built. */
       SpanBuilder withTag(String key, boolean value);
 
-      /** Same as {@link Span#setTag(String, String)}, but for the span being built. */
+      /** Same as {@link Span#setTag(String, Number)}, but for the span being built. */
       SpanBuilder withTag(String key, Number value);
 
-      /** Specify a timestamp of when the Span was started, represented in microseconds since epoch. */
+      /** Same as {@link Span#setBaggageItem(String, String)}, but for the span being built. */
       SpanBuilder withStartTimestamp(long microseconds);
+
+      /** Specify a timestamp of when the Span was started, represented in microseconds since epoch. */
+      SpanBuilder withBaggage(String key, String value);
 
       /** Returns the started Span. */
       Span start();

--- a/opentracing/src/main/java/io/opentracing/noop/NoopSpan.java
+++ b/opentracing/src/main/java/io/opentracing/noop/NoopSpan.java
@@ -13,6 +13,9 @@
  */
 package io.opentracing.noop;
 
+import java.util.Collections;
+import java.util.Set;
+
 import io.opentracing.Span;
 
 final class NoopSpan implements Span {
@@ -60,4 +63,9 @@ final class NoopSpan implements Span {
     public Span log(long timestampMicroseconds, String eventName, Object payload) {
         return this;
     }
+
+	@Override
+	public Set<String> getBaggageKeys() {
+		return Collections.emptySet();
+	}
 }

--- a/opentracing/src/main/java/io/opentracing/noop/NoopSpan.java
+++ b/opentracing/src/main/java/io/opentracing/noop/NoopSpan.java
@@ -29,6 +29,11 @@ final class NoopSpan implements Span {
 
     }
 
+	@Override
+	public void finish() {
+		
+	}
+	
     @Override
     public Span setTag(String key, String value) {
         return this;

--- a/opentracing/src/main/java/io/opentracing/noop/NoopSpan.java
+++ b/opentracing/src/main/java/io/opentracing/noop/NoopSpan.java
@@ -22,7 +22,7 @@ final class NoopSpan implements Span {
     private NoopSpan() {}
 
     @Override
-    public void finish() {
+    public void close() {
 
     }
 

--- a/opentracing/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
+++ b/opentracing/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
@@ -16,6 +16,7 @@ package io.opentracing.noop;
 
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import io.opentracing.Tracer.SpanBuilder;
 
 final class NoopSpanBuilder implements Tracer.SpanBuilder {
     static final Tracer.SpanBuilder Instance = new NoopSpanBuilder();
@@ -51,6 +52,11 @@ final class NoopSpanBuilder implements Tracer.SpanBuilder {
     public Tracer.SpanBuilder withStartTimestamp(long microseconds) {
         return this;
     }
+
+	@Override
+	public Tracer.SpanBuilder withBaggage(String key, String value) {
+		return this;
+	}
 
     @Override
     public Span start() {


### PR DESCRIPTION
Updated interface to make it possible for Span to be used in try-with-resource blocks to reduce some of the standard boilerplate code that's required to ensure that the finish method is called.  Treating Span as a resource allows for close (previously finish) to be closed in an automated way.