### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/opentracing-impl-java8/src/main/java/io/opentracing/propagation/AbstractSpanBuilder.java
+++ b/opentracing-impl-java8/src/main/java/io/opentracing/propagation/AbstractSpanBuilder.java
@@ -22,8 +22,6 @@ import java.util.concurrent.TimeUnit;
 
 abstract class AbstractSpanBuilder implements Tracer.SpanBuilder {
 
-    AbstractSpanBuilder() {}
-
     protected String operationName = null;
     protected Span parent = null;
     protected Instant start = Instant.now();
@@ -31,6 +29,8 @@ abstract class AbstractSpanBuilder implements Tracer.SpanBuilder {
     private final Map<String, Boolean> booleanTags = new HashMap<>();
     private final Map<String, Number> numberTags = new HashMap<>();
     private final Map<String, String> baggage = new HashMap<>();
+
+    AbstractSpanBuilder() {}
 
     /** Create a Span, using the builder fields. */
     protected abstract AbstractSpan createSpan();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat