### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/opentracing-impl-java8/src/main/java/io/opentracing/propagation/AbstractSpan.java
+++ b/opentracing-impl-java8/src/main/java/io/opentracing/propagation/AbstractSpan.java
@@ -26,9 +26,9 @@ import io.opentracing.Span;
 
 abstract class AbstractSpan implements Span {
 
-    final Map<String,String> baggage = new HashMap<>();
+    private final Map<String,String> baggage = new HashMap<>();
 
-    final String operationName;
+    protected final String operationName;
     private final Optional<Span> parent;
     private final Instant start;
     private Duration duration;

--- a/opentracing-impl-java8/src/main/java/io/opentracing/propagation/AbstractTracer.java
+++ b/opentracing-impl-java8/src/main/java/io/opentracing/propagation/AbstractTracer.java
@@ -23,7 +23,7 @@ import io.opentracing.Tracer.SpanBuilder;
 
 abstract class AbstractTracer implements Tracer {
 
-    static final boolean BAGGAGE_ENABLED = !Boolean.getBoolean("opentracing.propagation.dropBaggage");
+    protected static final boolean BAGGAGE_ENABLED = !Boolean.getBoolean("opentracing.propagation.dropBaggage");
 
     private final PropagationRegistry registry = new PropagationRegistry();
 

--- a/opentracing-impl/src/main/java/io/opentracing/NoopSpan.java
+++ b/opentracing-impl/src/main/java/io/opentracing/NoopSpan.java
@@ -15,7 +15,7 @@ package io.opentracing;
 
 final class NoopSpan implements Span {
 
-    static final NoopSpan INSTANCE = new NoopSpan();
+    protected static final NoopSpan INSTANCE = new NoopSpan();
 
     private NoopSpan() {}
 

--- a/opentracing-impl/src/main/java/io/opentracing/NoopSpanBuilder.java
+++ b/opentracing-impl/src/main/java/io/opentracing/NoopSpanBuilder.java
@@ -14,7 +14,7 @@
 package io.opentracing;
 
 final class NoopSpanBuilder implements Tracer.SpanBuilder {
-    static final Tracer.SpanBuilder INSTANCE = new NoopSpanBuilder();
+    protected static final Tracer.SpanBuilder INSTANCE = new NoopSpanBuilder();
 
     private NoopSpanBuilder() {}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat