### PR TITLE
Adds tag-based publishing to Maven Central

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>sonatype</id>
+      <username>${env.SONATYPE_USER}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>bintray</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_KEY}</password>
+    </server>
+    <server>
+      <id>jfrog-snapshots</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_KEY}</password>
+    </server>
+    <server>
+      <id>github.com</id>
+      <username>${env.GH_USER}</username>
+      <password>${env.GH_TOKEN}</password>
+    </server>
+  </servers>
+</settings>
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
-sudo: false
+# Default JDK is really old: 1.8.0_31; Trusty's is less old: 1.8.0_51
+# https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
+sudo: required
+dist: trusty
 
 cache:
   directories:
@@ -10,6 +13,43 @@ language: java
 jdk:
   - oraclejdk8
 
+
+before_install:
+  # Parameters used during release
+  - git config user.name "$GH_USER"
+  - git config user.email "$GH_USER_EMAIL"
+  # setup https authentication credentials, used by ./mvnw release:prepare
+  - git config credential.helper "store --file=.git/credentials"
+  - echo "https://$GH_TOKEN:@github.com" > .git/credentials
+
+install:
+  # Override default travis to use the maven wrapper
+  - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+
 script:
-  # use the maven wrapper as opposed to whatever version travis has
-  - ./mvnw install -nsu
+  - ./travis/publish.sh
+
+# Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.
+# See https://github.com/travis-ci/travis-ci/issues/1532
+branches:
+  except:
+    - /^[0-9]/
+
+env:
+  global:
+  # Ex. travis encrypt BINTRAY_USER=your_github_account
+  - secure: "QHoScwXVjj9mTZJuQ59jFvPr7Ri6tVgUyydk8Ba8CYDdgdNfnRzs3PW55g5iuC8Q8DJG6dsNfwWtYCagD8XIZw3bVE4Ic9hJJeOrY7PbaoB9gFb/emRYk83Z91xoYMXtaRCiOsxnXqMeyPd4rAc0mNOL5N00DjGVsDJp7BX4tAz0AL6mF4FNIkuuBIh7EEDpOJPSm4NXjUICaDQ8LETIVN69XvbVyoCu0lA2XIeSkXMq8O3izon4bch+fXe15z3LoWQQlmeK0YlEUZifPlIabIWErHEmjVrMVanIJu8B5SIF58pMhZ3AGL8PRBszDjMS+847LWCvW/VHsL9Le8pYXIxXksKw+DmioxudXV5jugDVy2qKsSIlUkP4MVFPwC4PktbFmn6lnYaN6YXoKj9dnGP5YjtWJdzHHqB9ovVWGq/XwI1m/V4KsMEUkX+PDlUoAa0C5iH1gCRGWfLwPw59wmxaBpsPQgAk1/2ynhNU2Q4TWDc167fZyu2O8to+nAKLX1gyLnsSKjstfWdg8LUGJJSzpNJ9OFJu1lxR/W/RQGy3Yg4nINC+nsBCBis7yRYcWHu1dm42ReFKPpzJgM2f06Hg5IA734NJFYeiHdC5mwdUNvpy/aKb30FljwhRnsczJnH9GKKi3vpTXzf0SU9VJPEuB2MwzUn6ZnI8cNtWE8U="
+  # Ex. travis encrypt BINTRAY_KEY=xxx-https://bintray.com/profile/edit-xxx --add
+  - secure: "PAtbtImeyHnjFR+yPVKggZgXb4oMXchM6YV3+qoYs6LExiqhwRPe4e+gAhfLESHUjiEoixAM77eAuk3Cqpklwtpy3Qwh3ptDtNm1d3VycDbhMVHkeIGaCJlHTitJHwegAHedrqH4qS3sRCG1Ke5Dxs1z1NtuLnIKhoiWKMW9SdNuLt+Wo+uYJnlr2Z78AVrChSsV4CiaJ5jZlFhRHO+cf22Xdx69Z2Imh7/3X+WBXIKqqNewegBlzvtQzZsknhFHmQV8UTJ1lCw6EcGOw5DXqqcRGmkRMsITeGMaUMd21Es2MeIHVsNS6aysLeAF15pbo3C9nhGJ11JWwNaeBVSpK+s8friNEOssJdvn+2W/NKrEHeKcEDwZRqKbOqUeGkwHb4n2nZd3oqc6/0O4Wf3q4bB1Dsh1PpL0tE5oeIbeUT0JMpk+MHIxzHyt5HuPnNqCk09psNbr110DiYNNddJKZOcv/hfxTuao55tbcg7C1tWYYcFxyMN3hE+EOEqhs3e4vOldFZSuF4/3lLYKBPl+Uin8eIUdzNQ01L3iy+FdB1haLS9V+kr72ZYABW0VdAj3Sw2GGsLsv5Xw2p8U3rcJBRm4mzrMSdfdN9YX2pOA/1Ch9rOiercKoy0hg2Q8PkORBJcOKS4uGPAAqrazAkpdih+sDTn7Sq+6sN1UNUR33fw="
+  # Ex. travis encrypt GH_USER_EMAIL=for_github@domain.com --add
+  - secure: "k8zW1018MXXSQ9CO7Wc3jkDbxAk7cRa7HG1O2Sr5VN0nFOOWlsf2Cpu8XY2J0Iniu25wkOB1ohyFW7X4xHTsvdiGZwxe0GPKKkKnKlQdUUKJD3O5ivdwN2BnTShfMEGq9owQ5v7gPoBpAfF06n8m9jUBI6jpt7ejTyuGnaeOumZxXoqUOASILZ+cXneJmFdXyyXymZf4DcEwmMIIvQDTdh2qX5AGQtuMGpZem1K/j2b25cIZS5iFJLBh/SplETDpNLkeRwQ1cZrOAf+bJPRPVuaMy40hauotuMszB1piK7Id4hBH5bGlKdX4lkgklUz9swFxV0soJS13v4NpXqoSJWUnyRfCnZvyvxx5moGVfYxzzG3iHloZ8SJXjHtc169eZyHg8viZWrIrtnoMt/SVMP7nvOJVN02nE++WyH8MgyE86eMwqGWLcEFMcCeE7ej1VPWX/7cVYfg1rTlX8qAAu+Ag+JDiGpql+FJSz5YRhffApuB1Pwu012NulpUFtrPeBu8QB9aC9PRpaXPoKa8hRyEN2qDr0y171Ua4TMxibn0WQw9wYRl0YGuTDi1TaFy/lxmpiVfp5FriXczO1WKbb27yaBQm/XYpxLr/Qz/+6xQG54wBhEj8uzlZwTFsjz5NfIDAQaVF61BRfTaKrN2pux+sFE11wXiz7A14oSdv9cg="
+  # Ex. travis encrypt GH_USER=your_github_account --add
+  - secure: "RqwejVFDlXrpq98ClntwT1KQPn38D2L54f5h9y1PNNCyuj9bioElRCECQtts41BomH8o0QSRsys22OyipGI6rXkGT74p0JJ14XCVStFC8Bx+xHuYTZ6ZQF9Q8HLcs/Il/iO6GW0/C555zuN8u8dK/79Fc146Vp0KKT/y5K1pDrWbdyUlg2ZfFhI0CIZ/ZcDZU2CrvaIU25JaaaN7c3OeckJcuWciRUhguOT4adfIOxfrT86mYhUhaqMzUFyIxVxhy2a5Dsc1ua0NtZ63Xiw4sMKWqbI0E542LGGxpE+7UnJxbe9bD2J945z/gz7dxfBGMJZxdVaCNgJ0kgnd0or3AUY6MLp1y58epOCuoVksHzu+06xomRGaId5RyaXXV+LI53TR097XppILKYNcxjoaCpH6MzrK8yu6e0/mB4fi+hKPtLNMIlKMiS6MMqvM9DgAfJikFxfc3gvm3e9Ve8W5sfVHh0ZIoGYAMp4ELMr1tcbry19H9qGAtYKS92HV7Py3W0hILBjAjIQZ3pIKpaQdyMtALK2p+4wCF0FQnPTS6NEEe3sVwmiSIV1i2DNwUtqtP8E1rDLZeJ2033Qw0nIM9zQwCELa9cpTAuguMRYbK/X0B+k8pAPxjC9LXANdePh/g4I8FDsAX6sdLbpMhuIl9OjcBUiKXuHnLqRPzsuYCzI="
+  # Ex. travis encrypt GH_TOKEN=XXX-https://github.com/settings/tokens-XXX --add
+  - secure: "n8Vv4rxhnRpLzhqj3j/iuduN4GeeB8UnyIS/mXnwViZ88L/EwGzpwXkV42igoXpTlafZzCRPwQC8q9hcut0T37F6cbVW8S1oGc8BdLNwiHve8JLRdA4f+0HUgzQeS8N/o2Dkgf41Ku105NR8JXtCezi7NxaL73ugp5NpqGKHriM91sYjQh7iU+2u7HxzGWPVt3DYKL5Qhvbr41FQCi01pRwOf51Xj4UCbn8xle0lEGXsaI1sBl+lABsLhIl5Eoc97GxFM9TXiKP35/BDlJ12Y9pa6i1swbhb5sgS/Zcbr8px55+1qa/AcG9lHoSwwoqwTlDLuWKC9TJ7NhwzkYa0w20/k5pfWYyO+W69JWb3+WEOObCii1td6D+u9Cyy8IL9cXTedADaBEQCfIITqXMqI311Lt3mR4YLJ3q7JiHs8YBoLQb6xpkeZqHbhWXdIuuOyMBlkO0nSpfXend1Skzwok0s0iIsOIYjjRe/QVpKFlQECDxJDUPQqAarbhaodh5wL50t71+kYTYmw5uou3Qb+Cm5ZUkJmK01qya6lE3Oa0GHTJiK5qiciA0O0yVQtf7uwuBnRvN/b6EvwWdJpTUUYYM25yBY4v8oI/z4gcD0RMC0AZVj8em6KmbWhYduSDLgsNm+EYQ/9ziJTYEWP2Obd4BhOcSVxUEPn7aLVz6WGtw="
+  # Ex. travis encrypt SONATYPE_USER=your_sonatype_account
+  - secure: "oE16AjpS/aabLRNkQN6SmyfYJwCwBqYOvqyhPPZCYDYfZpBtJHugUXdds9GYc6BXfgPKF3QJQ727dPqXrmbh9UPkSyE1LYv1De/HbGsPmwBn+S2fg1Id2BrV3qVPg7aYaO8EX0zIxfh5BxY0woC4Lj9Wl5EbTYf00h/JhCaKr1ZYR9/gzG8Ngyexr+FLlKFCKhka+3iEcwCz8feyxcPCsgGo3TiNI42Q9cLGpqGAuStQcwUZe2296qQd1Zn9khZYpP5bm7+mOCI62xXI+PEIES+ss/kB8b9pfUiHgfxtKS6gs4I3oDEelJw3fjrHdsgMs6YfLTPp9yKMMqSIzcp4dmqOf5zxadCKQ+eETervLJEngZAwzuAvdeh8/9Az8eN96FDfKWrf8tkbkdzY9Ajqk5qra4vx87ChQ/u6Am9OV6dqwIBU4i7sBUa55jXQns8gE2nT+R0xAM57Arolr768QriPAiUlom8AmeUryUWj1S8JC+jjNhw0v9wFk2JEkrY1WBrCStnCYAPZ3CP5uoNGsQS42t0Cd05TtjHjnJE8EHfHHFiWSF1+ov7GkAQQXqH473T1Be7HPJo9EQ5PRsea5li2AtTU80dBuCaeqBnE6Tm1kuiVDrDo3kO/+C5fjF065z1Xvl42pcJhlYH/uNItQbGiFfcBP6hT3szVIDeSElc="
+  # Ex. travis encrypt SONATYPE_PASSWORD=your_sonatype_password
+  - secure: "jWfEmREf5VjjJwvlAA+11a8DYQa4ZZzhfUOkUObO0do1fG+aQtMKndesa0h8xETGggySEc5nn0e7THJ5EjBlppNtH7LqK1bfgTF4PlkMwHOkhGjLaoxCpT0HVyAaWUEZdD8uGwiY+NkLc3AC06fhB3MjpMbM82tOWXOpWLxnLpLgqP9L1DM/9uWiD36T3k6vkVABHGoGmQPgyXiTL6NHhNLVlI44L++ddXHGxrCEOs4oFhP7MXtR5T+51Bdalpj6eko4nP4/mve+5KMH8mzays04YX0F2TxtCXmgqLAeHE5AWm/A++85bJqnIwyApdT0A1NQR2GAJN6FyeA/zTCslbIMt2sqg0auXikCRbkwhom56E6KDbnyXoE9VfViMmaTT9FF/d3vIV29BiCitfbVmUMXcsFQEljhPigbva3ayHHdOsBbI2KTvH+rbzPHv6Jqp0TQJlE9qU2qTVS2bWHPyOltbyx2KiSJUwx5zqsC20J7lnPgqWCYXEVzyS2wwzFm752bxIRGAeghgVVdTnPST1Lu7Z/LQ3Vt827juk1qAU9HzVPu+OmJS6os0EIzAWZoC9KksYvslv0mUlmc5IbEDqdqK5MA/bw72Vv8KOlVbJPQ5XC26utF/44Gn35nx8OI/yg1Qkdoj/iISnk4b/oCOLr9l39xsTZUj7HhrnlLbbM="
+
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+# OpenTracing Release Process
+
+This repo uses semantic versions. Please keep this in mind when choosing version numbers.
+
+1. **Alert others you are releasing**
+
+   There should be no commits made to master while the release is in progress (about 10 minutes). Before you start
+   a release, alert others on [gitter](https://gitter.im/opentracing/public) so that they don't accidentally merge
+   anything. If they do, and the build fails because of that, you'll have to recreate the release tag described below.
+
+1. **Push a git tag**
+
+   The tag should be of the format `release-N.M.L`, for example `release-3.7.1`.
+
+1. **Wait for Travis CI**
+
+   This part is controlled by [`travis/publish.sh`](travis/publish.sh). It creates a bunch of new commits, bumps
+   the version, publishes artifacts, and syncs to Maven Central.

--- a/opentracing-api/pom.xml
+++ b/opentracing-api/pom.xml
@@ -31,55 +31,5 @@
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
-        <animal-sniffer-maven-plugin.version>1.14</animal-sniffer-maven-plugin.version>
     </properties>
-
-    <build>
-        <plugins>
-            <!-- Ensure main source tree compiles to Java 7 bytecode. This allows higher
-                 reuse, including android, which doesn't support Java 8 features. -->
-            <plugin>
-                <inherited>true</inherited>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <!-- Default is still 1.8, specifically for use in tests. -->
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <source>1.7</source>
-                            <target>1.7</target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- Language-level aside, make sure Java 8 types and methods aren't used -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal-sniffer-maven-plugin.version}</version>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java17</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/opentracing-impl-java8/pom.xml
+++ b/opentracing-impl-java8/pom.xml
@@ -31,63 +31,14 @@
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
-        <animal-sniffer-maven-plugin.version>1.14</animal-sniffer-maven-plugin.version>
+        <main.java.version>1.8</main.java.version>
+        <main.signature.artifact>java18</main.signature.artifact>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>io.opentracing</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>opentracing-impl</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <!-- Ensure main source tree compiles to Java 7 bytecode. This allows higher
-                 reuse, including android, which doesn't support Java 8 features. -->
-            <plugin>
-                <inherited>true</inherited>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <!-- Default is still 1.8, specifically for use in tests. -->
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- Language-level aside, make sure Java 8 types and methods aren't used -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal-sniffer-maven-plugin.version}</version>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java18</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/opentracing-impl/pom.xml
+++ b/opentracing-impl/pom.xml
@@ -31,63 +31,12 @@
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
-        <animal-sniffer-maven-plugin.version>1.14</animal-sniffer-maven-plugin.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>io.opentracing</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>opentracing-api</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <!-- Ensure main source tree compiles to Java 7 bytecode. This allows higher
-                 reuse, including android, which doesn't support Java 8 features. -->
-            <plugin>
-                <inherited>true</inherited>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <!-- Default is still 1.8, specifically for use in tests. -->
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <source>1.7</source>
-                            <target>1.7</target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- Language-level aside, make sure Java 8 types and methods aren't used -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal-sniffer-maven-plugin.version}</version>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java17</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
-        <!-- The default language level is 1.8 even if some core classes may be 1.7 -->
+        <!-- default bytecode version for src/main -->
+        <main.java.version>1.7</main.java.version>
+        <main.signature.artifact>java17</main.signature.artifact>
+
+        <!-- default bytecode version for src/test -->
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
@@ -43,12 +47,16 @@
         <junit.version>4.12</junit.version>
         <assertj.version>3.2.0</assertj.version>
 
+        <animal-sniffer-maven-plugin.version>1.15</animal-sniffer-maven-plugin.version>
         <maven-plugin.version>0.3.3</maven-plugin.version>
+        <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-        <maven-source-plugin.version>2.4</maven-source-plugin.version>
+        <maven-source-plugin.version>3.0.0</maven-source-plugin.version>
         <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
-        <maven-license-plugin.version>2.11</maven-license-plugin.version>
+        <license-maven-plugin.version>2.11</license-maven-plugin.version>
         <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <centralsync-maven-plugin.version>0.1.0</centralsync-maven-plugin.version>
     </properties>
 
     <name>OpenTracing (Parent)</name>
@@ -72,8 +80,7 @@
     <scm>
         <url>https://github.com/opentracing/opentracing-java</url>
         <connection>scm:git:https://github.com/opentracing/opentracing-java.git</connection>
-        <developerConnection>scm:git:https://github.com/opentracing/opentracing-java.git
-        </developerConnection>
+        <developerConnection>scm:git:https://github.com/opentracing/opentracing-java.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 
@@ -90,6 +97,17 @@
         </developer>
     </developers>
 
+    <distributionManagement>
+        <repository>
+            <id>bintray</id>
+            <url>https://api.bintray.com/maven/opentracing/maven/opentracing-java/;publish=1</url>
+        </repository>
+        <snapshotRepository>
+            <id>jfrog-snapshots</id>
+            <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <issueManagement>
         <system>Github</system>
         <url>https://github.com/opentracing/opentracing-java/issues</url>
@@ -99,7 +117,19 @@
         <dependencies>
             <dependency>
                 <groupId>${project.groupId}</groupId>
-                <artifactId>opentracing</artifactId>
+                <artifactId>opentracing-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>opentracing-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>opentracing-impl-java8</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -142,6 +172,11 @@
                 </plugin>
 
                 <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
+
+                <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven-jar-plugin.version}</version>
                 </plugin>
@@ -149,6 +184,44 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <inherited>true</inherited>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <!-- Ensure main source tree compiles to Java ${main.java.version} bytecode. -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>${main.java.version}</source>
+                            <target>${main.java.version}</target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>${animal-sniffer-maven-plugin.version}</version>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>${main.signature.artifact}</artifactId>
+                        <version>1.0</version>
+                    </signature>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
             <!-- Ensures checksums are added to published jars -->
             <plugin>
@@ -162,7 +235,7 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>${maven-license-plugin.version}</version>
+                <version>${license-maven-plugin.version}</version>
                 <configuration>
                     <header>${main.basedir}/src/etc/header.txt</header>
                     <excludes>
@@ -183,7 +256,7 @@
                     <dependency>
                         <groupId>com.mycila</groupId>
                         <artifactId>license-maven-plugin-git</artifactId>
-                        <version>${maven-license-plugin.version}</version>
+                        <version>${license-maven-plugin.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -194,6 +267,28 @@
                         <phase>compile</phase>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin.version}</version>
+                <configuration>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>io.zipkin.centralsync-maven-plugin</groupId>
+                <artifactId>centralsync-maven-plugin</artifactId>
+                <version>${centralsync-maven-plugin.version}</version>
+                <configuration>
+                    <subject>opentracing</subject>
+                    <repo>maven</repo>
+                    <packageName>opentracing-java</packageName>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,0 +1,131 @@
+#
+# Copyright 2016 The OpenTracing Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -euo pipefail
+set -x
+
+build_started_by_tag() {
+  if [ "${TRAVIS_TAG}" == "" ]; then
+    echo "[Publishing] This build was not started by a tag, publishing snapshot"
+    return 1
+  else
+    echo "[Publishing] This build was started by the tag ${TRAVIS_TAG}, publishing release"
+    return 0
+  fi
+}
+
+is_pull_request() {
+  if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    echo "[Not Publishing] This is a Pull Request"
+    return 0
+  else
+    echo "[Publishing] This is not a Pull Request"
+    return 1
+  fi
+}
+
+is_travis_branch_master() {
+  if [ "${TRAVIS_BRANCH}" = master ]; then
+    echo "[Publishing] Travis branch is master"
+    return 0
+  else
+    echo "[Not Publishing] Travis branch is not master"
+    return 1
+  fi
+}
+
+check_travis_branch_equals_travis_tag() {
+  #Weird comparison comparing branch to tag because when you 'git push --tags'
+  #the branch somehow becomes the tag value
+  #github issue: https://github.com/travis-ci/travis-ci/issues/1675
+  if [ "${TRAVIS_BRANCH}" != "${TRAVIS_TAG}" ]; then
+    echo "Travis branch does not equal Travis tag, which it should, bailing out."
+    echo "  github issue: https://github.com/travis-ci/travis-ci/issues/1675"
+    exit 1
+  else
+    echo "[Publishing] Branch (${TRAVIS_BRANCH}) same as Tag (${TRAVIS_TAG})"
+  fi
+}
+
+check_release_tag() {
+    tag="${TRAVIS_TAG}"
+    if [[ "$tag" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+        echo "Build started by version tag $tag. During the release process tags like this"
+        echo "are created by the 'release' Maven plugin. Nothing to do here."
+        exit 0
+    elif [[ ! "$tag" =~ ^release-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+        echo "You must specify a tag of the format 'release-0.0.0' to release this project."
+        echo "The provided tag ${tag} doesn't match that. Aborting."
+        exit 1
+    fi
+}
+
+is_release_commit() {
+  project_version=$(./mvnw help:evaluate -N -Dexpression=project.version|grep -v '\[')
+  if [[ "$project_version" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+    echo "Build started by release commit $project_version. Will synchronize to maven central."
+    return 0
+  else
+    return 1
+  fi
+}
+
+release_version() {
+    echo "${TRAVIS_TAG}" | sed 's/^release-//'
+}
+
+safe_checkout_master() {
+  # We need to be on a branch for release:perform to be able to create commits, and we want that branch to be master.
+  # But we also want to make sure that we build and release exactly the tagged version, so we verify that the remote
+  # master is where our tag is.
+  git checkout -B master
+  git fetch origin master:origin/master
+  commit_local_master="$(git show --pretty='format:%H' master)"
+  commit_remote_master="$(git show --pretty='format:%H' origin/master)"
+  if [ "$commit_local_master" != "$commit_remote_master" ]; then
+    echo "Master on remote 'origin' has commits since the version under release, aborting"
+    exit 1
+  fi
+}
+
+#----------------------
+# MAIN
+#----------------------
+
+if ! is_pull_request && build_started_by_tag; then
+  check_travis_branch_equals_travis_tag
+  check_release_tag
+fi
+
+./mvnw install -nsu
+
+# If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
+if is_pull_request; then
+  true
+# If we are on master, we will deploy the latest snapshot or release version
+#   - If a release commit fails to deploy for a transient reason, delete the broken version from bintray and click rebuild
+elif is_travis_branch_master; then
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
+
+  # If the deployment succeeded, sync it to Maven Central. Note: this needs to be done once per project, not module, hence -N
+  if is_release_commit; then
+    ./mvnw --batch-mode -s ./.settings.xml -nsu -N io.zipkin.centralsync-maven-plugin:centralsync-maven-plugin:sync
+  fi
+
+# If we are on a release tag, the following will update any version references and push a version tag for deployment.
+elif build_started_by_tag; then
+  safe_checkout_master
+  ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare
+fi
+


### PR DESCRIPTION
This re-uses the deployment flow from zipkin-java which has the
following features:

* Makes OpenTracing Java releaseable by anyone with access to the Bintray org
* Snapshot publishing to http://oss.jfrog.org/artifactory/oss-snapshot-local
* Fully automated release to maven central via release-N.N.N tag
  * Releases also published to https://jcenter.bintray.com

Fixes #3