### PR TITLE
Expose public singleton instance of NoopTracer

### DIFF
--- a/opentracing-impl/src/main/java/io/opentracing/NoopTracer.java
+++ b/opentracing-impl/src/main/java/io/opentracing/NoopTracer.java
@@ -17,7 +17,7 @@ import io.opentracing.propagation.Format;
 
 public final class NoopTracer implements Tracer {
 
-    public final static INSTANCE = new NoopTracer();
+    public final static NoopTracer INSTANCE = new NoopTracer();
 
     @Override
     public SpanBuilder buildSpan(String operationName) {

--- a/opentracing-impl/src/main/java/io/opentracing/NoopTracer.java
+++ b/opentracing-impl/src/main/java/io/opentracing/NoopTracer.java
@@ -17,6 +17,8 @@ import io.opentracing.propagation.Format;
 
 public final class NoopTracer implements Tracer {
 
+    public final static INSTANCE = new NoopTracer();
+
     @Override
     public SpanBuilder buildSpan(String operationName) {
         return NoopSpanBuilder.INSTANCE;


### PR DESCRIPTION
All other classes in this package expose singletons, any reason not to do the same for NoopTracer?