### PR TITLE
A child of a NoopSpan is a NoopSpan.

### DIFF
--- a/opentracing-api/src/test/java/io/opentracing/AssertionTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/AssertionTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing;
+
+import org.junit.Test;
+
+public final class AssertionTest {
+
+    @Test
+    public void test_assertions_enabled() {
+        boolean asserted = false;
+        try {
+            assert false;
+        } catch (AssertionError error) {
+            asserted = true;
+        }
+        if (!asserted) {
+            throw new AssertionError("assertions are not enabled");
+        }
+    }
+}

--- a/opentracing-impl-java8/src/main/java/io/opentracing/AbstractSpanBuilder.java
+++ b/opentracing-impl-java8/src/main/java/io/opentracing/AbstractSpanBuilder.java
@@ -13,6 +13,7 @@
  */
 package io.opentracing;
 
+import io.opentracing.Tracer.SpanBuilder;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -51,12 +52,18 @@ abstract class AbstractSpanBuilder implements Tracer.SpanBuilder {
     }
 
     @Override
-    public final AbstractSpanBuilder asChildOf(SpanContext parent) {
+    public final SpanBuilder asChildOf(SpanContext parent) {
+        if (NoopSpanBuilder.INSTANCE == parent || NoopSpan.INSTANCE.context() == parent) {
+            return NoopSpanBuilder.INSTANCE;
+        }
         return this.addReference(References.CHILD_OF, parent);
     }
 
     @Override
-    public final AbstractSpanBuilder asChildOf(Span parent) {
+    public final SpanBuilder asChildOf(Span parent) {
+        if (NoopSpan.INSTANCE == parent) {
+            return NoopSpanBuilder.INSTANCE;
+        }
         return this.addReference(References.CHILD_OF, parent.context());
     }
 

--- a/opentracing-impl-java8/src/test/java/io/opentracing/AbstractTracerTest.java
+++ b/opentracing-impl-java8/src/test/java/io/opentracing/AbstractTracerTest.java
@@ -89,6 +89,23 @@ public final class AbstractTracerTest {
         assertEquals("Should find the marker", "whatever", ((TestSpanBuilder)result).operationName);
     }
 
+    @Test
+    public void testExtractAsParent() throws Exception {
+        Map<String,String> map = Collections.singletonMap("test-marker", "whatever");
+        TextMapExtractAdapter adapter = new TextMapExtractAdapter(map);
+        AbstractTracer tracer = new TestTracerImpl();
+        SpanContext parent = tracer.extract(Format.Builtin.TEXT_MAP, adapter);
+        assert NoopSpan.INSTANCE != tracer.buildSpan("child").asChildOf(parent).start();
+    }
+
+    @Test
+    public void testExtractOfNoParent() throws Exception {
+        AbstractTracer tracer = new TestTracerImpl();
+        assert NoopSpan.INSTANCE == tracer.buildSpan("child").asChildOf(NoopSpan.INSTANCE).start();
+        assert NoopSpan.INSTANCE == tracer.buildSpan("child").asChildOf(NoopSpan.CONTEXT).start();
+        assert NoopSpan.INSTANCE == tracer.buildSpan("child").asChildOf(NoopSpanBuilder.INSTANCE).start();
+    }
+
     final class TestTracerImpl extends AbstractTracer {
 
         static final String OPERATION_NAME = "operation-name";


### PR DESCRIPTION
If a NoopSpan or Noop SpanContext is declared as a parent to the span during the SpanBuilder usage, then return the NoopSpanBuilder.