### PR TITLE
Fixes class cast exception , and Solves #45

### DIFF
--- a/opentracing-api/pom.xml
+++ b/opentracing-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.opentracing</groupId>
         <artifactId>parent</artifactId>
-        <version>0.16.1-SNAPSHOT</version>
+        <version>0.17-SNAPSHOT</version>
     </parent>
 
     <artifactId>opentracing-api</artifactId>

--- a/opentracing-api/src/test/java/io/opentracing/AssertionTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/AssertionTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing;
+
+import org.junit.Test;
+
+public final class AssertionTest {
+
+    @Test
+    public void test_assertions_enabled() {
+        boolean asserted = false;
+        try {
+            assert false;
+        } catch (AssertionError error) {
+            asserted = true;
+        }
+        if (!asserted) {
+            throw new AssertionError("assertions are not enabled");
+        }
+    }
+}

--- a/opentracing-impl/pom.xml
+++ b/opentracing-impl/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.opentracing</groupId>
         <artifactId>parent</artifactId>
-        <version>0.16.1-SNAPSHOT</version>
+        <version>0.17-SNAPSHOT</version>
     </parent>
 
     <artifactId>opentracing-impl</artifactId>
@@ -29,12 +29,18 @@
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
+        <main.java.version>1.8</main.java.version>
+        <main.signature.artifact>java18</main.signature.artifact>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>opentracing-noop</artifactId>
         </dependency>
     </dependencies>
 

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpan.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpan.java
@@ -11,11 +11,17 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opentracing;
+package io.opentracing.impl;
 
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 abstract class AbstractSpan implements Span, SpanContext {

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanBuilder.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanBuilder.java
@@ -11,8 +11,12 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opentracing;
+package io.opentracing.impl;
 
+import io.opentracing.References;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,12 +56,16 @@ abstract class AbstractSpanBuilder implements Tracer.SpanBuilder {
 
     @Override
     public final AbstractSpanBuilder asChildOf(SpanContext parent) {
-        return this.addReference(References.CHILD_OF, parent);
+        return io.opentracing.NoopSpanContext.class.isAssignableFrom(parent.getClass())
+                ? NoopSpanBuilder.INSTANCE
+                : this.addReference(References.CHILD_OF, parent);
     }
 
     @Override
     public final AbstractSpanBuilder asChildOf(Span parent) {
-        return this.addReference(References.CHILD_OF, parent.context());
+        return io.opentracing.NoopSpan.class.isAssignableFrom(parent.getClass())
+                ? NoopSpanBuilder.INSTANCE
+                : this.addReference(References.CHILD_OF, parent.context());
     }
 
     @Override

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractTracer.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractTracer.java
@@ -11,8 +11,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opentracing;
+package io.opentracing.impl;
 
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import io.opentracing.propagation.Extractor;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.Injector;

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpan.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpan.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2016 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.impl;
+
+import io.opentracing.NoopSpanContext;
+import io.opentracing.Span;
+
+final class NoopSpan extends AbstractSpan implements io.opentracing.NoopSpan, NoopSpanContext {
+
+    static final NoopSpan INSTANCE = new NoopSpan("noop");
+
+    public NoopSpan(String operationName) {
+        super(operationName);
+    }
+
+    @Override
+    public void finish() {
+    }
+
+    @Override
+    public void finish(long finishMicros) {
+    }
+
+    @Override
+    public String getBaggageItem(String key) {
+        return io.opentracing.NoopSpan.INSTANCE.getBaggageItem(key);
+    }
+
+    @Override
+    public Span setOperationName(String operationName) {
+        return this;
+    }
+
+}

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpanBuilder.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpanBuilder.java
@@ -11,23 +11,30 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opentracing;
+package io.opentracing.impl;
 
-import io.opentracing.propagation.Format;
+import io.opentracing.NoopSpanContext;
 
-public final class NoopTracer implements Tracer {
+final class NoopSpanBuilder extends AbstractSpanBuilder implements io.opentracing.NoopSpanBuilder, NoopSpanContext {
 
-    public final static NoopTracer INSTANCE = new NoopTracer();
+    static final NoopSpanBuilder INSTANCE = new NoopSpanBuilder("noop");
 
-    @Override
-    public SpanBuilder buildSpan(String operationName) {
-        return NoopSpanBuilder.INSTANCE;
+    public NoopSpanBuilder(String operationName) {
+        super(operationName);
     }
 
     @Override
-    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {}
+    protected AbstractSpan createSpan() {
+        return NoopSpan.INSTANCE;
+    }
 
     @Override
-    public <C> SpanBuilder extract(Format<C> format, C carrier) { return NoopSpanBuilder.INSTANCE; }
+    AbstractSpanBuilder withStateItem(String key, Object value) {
+        return this;
+    }
 
+    @Override
+    boolean isTraceState(String key, Object value) {
+        return false;
+    }
 }

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopTracer.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopTracer.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.impl;
+
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import java.util.Collections;
+import java.util.Map;
+
+final class NoopTracer extends AbstractTracer implements io.opentracing.NoopTracer {
+
+    private static final NoopTracer INSTANCE = new NoopTracer();
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {}
+
+    @Override
+    public <C> SpanBuilder extract(Format<C> format, C carrier) {
+        return io.opentracing.NoopSpanBuilder.INSTANCE;
+    }
+
+    @Override
+    AbstractSpanBuilder createSpanBuilder(String operationName) {
+        return NoopSpanBuilder.INSTANCE;
+    }
+
+    @Override
+    Map<String, Object> getTraceState(SpanContext spanContext) {
+        return Collections.emptyMap();
+    }
+
+
+}

--- a/opentracing-impl/src/main/java/io/opentracing/impl/TextMapInjectorImpl.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/TextMapInjectorImpl.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.impl;
+
+import io.opentracing.SpanContext;
+import java.util.Map;
+
+import io.opentracing.propagation.Injector;
+import io.opentracing.propagation.TextMap;
+
+final class TextMapInjectorImpl implements Injector<TextMap> {
+
+    private final AbstractTracer tracer;
+    private boolean baggageEnabled = AbstractTracer.BAGGAGE_ENABLED;
+
+    TextMapInjectorImpl(AbstractTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public void inject(SpanContext spanContext, TextMap carrier) {
+
+        for (Map.Entry<String,Object> entry : tracer.getTraceState(spanContext).entrySet()) {
+            carrier.put(entry.getKey(), entry.getValue().toString());
+        }
+        if (baggageEnabled) {
+            for (Map.Entry<String,String> entry : ((AbstractSpan)spanContext).baggageItems()) {
+                carrier.put(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    void setBaggageEnabled(boolean baggageEnabled) {
+        this.baggageEnabled = baggageEnabled;
+    }
+
+}

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanBuilder.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanBuilder.java
@@ -11,7 +11,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opentracing;
+package io.opentracing.impl;
+
+import io.opentracing.impl.AbstractSpan;
+import io.opentracing.impl.AbstractSpanBuilder;
 
 
 final class TestSpanBuilder extends AbstractSpanBuilder {

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanImpl.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanImpl.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2016 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.impl;
+
+import io.opentracing.impl.AbstractSpan;
+
+public class TestSpanImpl extends AbstractSpan {
+
+    TestSpanImpl(String operationName) {
+        super(operationName);
+    }
+}

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapExtractorImpl.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapExtractorImpl.java
@@ -11,33 +11,25 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opentracing;
+package io.opentracing.impl;
 
-import java.util.Map;
-
+import io.opentracing.Tracer.SpanBuilder;
 import io.opentracing.propagation.Extractor;
 import io.opentracing.propagation.TextMap;
 
-final class TextMapExtractorImpl implements Extractor<TextMap> {
+import java.util.Map;
 
-    private final AbstractTracer tracer;
-
-    TextMapExtractorImpl(AbstractTracer tracer) {
-        this.tracer = tracer;
-    }
+final class TestTextMapExtractorImpl implements Extractor<TextMap> {
 
     @Override
-    public Tracer.SpanBuilder extract(TextMap carrier) {
-
-        AbstractSpanBuilder builder = tracer.createSpanBuilder("extracted");
-        for (Map.Entry<String, String> entry : carrier) {
-            if (builder.isTraceState(entry.getKey(), entry.getValue())) {
-                builder.withStateItem(entry.getKey(), entry.getValue());
-            } else {
-                builder.withBaggageItem(entry.getKey(), entry.getValue());
+    public SpanBuilder extract(TextMap carrier) {
+        String marker = null;
+        for (Map.Entry<String,String> entry : carrier) {
+            if (entry.getKey().equals("test-marker")) {
+                marker = entry.getValue();
             }
         }
-        return builder;
-    }
 
+        return null != marker ? new TestSpanBuilder(marker) : NoopSpanBuilder.INSTANCE;
+    }
 }

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapInjectorImpl.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapInjectorImpl.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2016 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.impl;
+
+import io.opentracing.SpanContext;
+import io.opentracing.impl.AbstractSpan;
+import io.opentracing.propagation.Injector;
+import io.opentracing.propagation.TextMap;
+
+final class TestTextMapInjectorImpl implements Injector<TextMap> {
+    @Override
+    public void inject(SpanContext spanContext, TextMap carrier) {
+        carrier.put("test-marker", ((AbstractSpan)spanContext).getOperationName());
+    }
+}

--- a/opentracing-mock/pom.xml
+++ b/opentracing-mock/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.opentracing</groupId>
         <artifactId>parent</artifactId>
-        <version>0.16.1-SNAPSHOT</version>
+        <version>0.17-SNAPSHOT</version>
     </parent>
 
     <artifactId>opentracing-mock</artifactId>

--- a/opentracing-noop/pom.xml
+++ b/opentracing-noop/pom.xml
@@ -20,23 +20,21 @@
     <parent>
         <groupId>io.opentracing</groupId>
         <artifactId>parent</artifactId>
-        <version>0.16.1-SNAPSHOT</version>
+        <version>0.17-SNAPSHOT</version>
     </parent>
 
-    <artifactId>opentracing-impl-java8</artifactId>
-    <name>OpenTracing-impl-java8</name>
-    <description>OpenTracing Java8 implementation</description>
+    <artifactId>opentracing-noop</artifactId>
+    <name>OpenTracing-noop</name>
+    <description>OpenTracing NoOp</description>
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
-        <main.java.version>1.8</main.java.version>
-        <main.signature.artifact>java18</main.signature.artifact>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>opentracing-impl</artifactId>
+            <artifactId>opentracing-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpan.java
@@ -13,24 +13,17 @@
  */
 package io.opentracing;
 
-import java.util.Collections;
 import java.util.Map;
 
-final class NoopSpan implements Span {
+public interface NoopSpan extends Span {
+    static final NoopSpan INSTANCE = new NoopSpanImpl();
+}
 
-    static final NoopSpan INSTANCE = new NoopSpan();
+final class NoopSpanImpl implements NoopSpan {
 
-    static final SpanContext CONTEXT = new SpanContext() {
-        @Override
-        public Iterable<Map.Entry<String, String>> baggageItems() {
-            return Collections.EMPTY_MAP.entrySet();
-        }
-    };
-
-    private NoopSpan() {}
 
     @Override
-    public SpanContext context() { return CONTEXT; }
+    public SpanContext context() { return NoopSpanContextImpl.INSTANCE; }
 
     @Override
     public void finish() {}
@@ -78,3 +71,4 @@ final class NoopSpan implements Span {
     public Span setOperationName(String operationName) { return this; }
 
 }
+

--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpanBuilder.java
@@ -16,10 +16,11 @@ package io.opentracing;
 import java.util.Collections;
 import java.util.Map;
 
-public final class NoopSpanBuilder implements Tracer.SpanBuilder {
-    public static final Tracer.SpanBuilder INSTANCE = new NoopSpanBuilder();
+public interface NoopSpanBuilder extends Tracer.SpanBuilder {
+    static final NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
+}
 
-    private NoopSpanBuilder() {}
+final class NoopSpanBuilderImpl implements NoopSpanBuilder {
 
     @Override
     public Tracer.SpanBuilder addReference(String refType, SpanContext referenced) {
@@ -58,7 +59,7 @@ public final class NoopSpanBuilder implements Tracer.SpanBuilder {
 
     @Override
     public Span start() {
-        return NoopSpan.INSTANCE;
+        return NoopSpanImpl.INSTANCE;
     }
 
     @Override

--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpanContext.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpanContext.java
@@ -13,9 +13,19 @@
  */
 package io.opentracing;
 
-public class TestSpanImpl extends AbstractSpan {
+import java.util.Collections;
+import java.util.Map;
 
-    TestSpanImpl(String operationName) {
-        super(operationName);
+
+public interface NoopSpanContext extends SpanContext {
+}
+
+final class NoopSpanContextImpl implements NoopSpanContext {
+    static final NoopSpanContextImpl INSTANCE = new NoopSpanContextImpl();
+
+    @Override
+    public Iterable<Map.Entry<String, String>> baggageItems() {
+        return Collections.emptyList();
     }
+
 }

--- a/opentracing-noop/src/main/java/io/opentracing/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopTracer.java
@@ -13,12 +13,22 @@
  */
 package io.opentracing;
 
-import io.opentracing.propagation.Injector;
-import io.opentracing.propagation.TextMap;
+import io.opentracing.propagation.Format;
 
-final class TestTextMapInjectorImpl implements Injector<TextMap> {
-    @Override
-    public void inject(SpanContext spanContext, TextMap carrier) {
-        carrier.put("test-marker", ((AbstractSpan)spanContext).getOperationName());
-    }
+public interface NoopTracer extends Tracer {
 }
+
+final class NoopTracerImpl implements NoopTracer {
+    final static NoopTracer INSTANCE = new NoopTracerImpl();
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) { return NoopSpanBuilderImpl.INSTANCE; }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {}
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) { return NoopSpanBuilderImpl.INSTANCE; }
+
+}
+

--- a/opentracing-noop/src/main/java/io/opentracing/NoopTracerFactory.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopTracerFactory.java
@@ -13,23 +13,12 @@
  */
 package io.opentracing;
 
-import io.opentracing.Tracer.SpanBuilder;
-import io.opentracing.propagation.Extractor;
-import io.opentracing.propagation.TextMap;
-
-import java.util.Map;
-
-final class TestTextMapExtractorImpl implements Extractor<TextMap> {
-
-    @Override
-    public SpanBuilder extract(TextMap carrier) {
-        String marker = null;
-        for (Map.Entry<String,String> entry : carrier) {
-            if (entry.getKey().equals("test-marker")) {
-                marker = entry.getValue();
-            }
-        }
-
-        return null != marker ? new TestSpanBuilder(marker) : NoopSpanBuilder.INSTANCE;
+public final class NoopTracerFactory {
+    
+    public static NoopTracer create() {
+        return NoopTracerImpl.INSTANCE;
     }
+
+    private NoopTracerFactory() {}
 }
+

--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,13 @@
 
     <groupId>io.opentracing</groupId>
     <artifactId>parent</artifactId>
-    <version>0.16.1-SNAPSHOT</version>
+    <version>0.17-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
         <module>opentracing-api</module>
+        <module>opentracing-noop</module>
         <module>opentracing-impl</module>
-        <module>opentracing-impl-java8</module>
         <module>opentracing-mock</module>
     </modules>
 
@@ -83,19 +83,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <developers>
-        <developer>
-            <id>bensigelman</id>
-            <name>Ben Sigelman</name>
-            <email>bhs@resonancelabs.com</email>
-        </developer>
-        <developer>
-            <id>adriancole</id>
-            <name>Adrian Cole</name>
-            <email>acole@pivotal.io</email>
-        </developer>
-    </developers>
-
     <distributionManagement>
         <repository>
             <id>bintray</id>
@@ -123,6 +110,12 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>opentracing-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>opentracing-noop</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
A child of a NoopSpan is a NoopSpan (without explicit forced sampling).
If a NoopSpan or Noop SpanContext is declared as a parent to the span during the SpanBuilder usage, then return the NoopSpanBuilder. This has been re-implemented so that a) Noop objects are separate entities in the opentracing landscape which can not be mix-and-matched, and b) can re-use them by concept so to enable fluent APIs (ie avoiding nulls being passed around).

**Actions**
Merge impl and impl-java8 to avoid confusion regarding their roles.
Move Noop classes to their own component "opentracing-noop" where they can't be confused to be part of, or mix-and-matched with, the impl classes.
Move the Noop classes into interfaces, while creating default implementations of this. This (along with using the create() factory method name) indicates that this is a marker interface and the instance only should not be compared against.

Opentracing-impl subclasses (extends) the Noop interfaces to provide an empty (or None) instance to the abstract classes provided. This prevents mix-and-match. Such an approach can be repeated by specific implementations too if they like.

**References**
Addressing the ClassCastException that is currently thrown when extract(..) is used.
Also solves https://github.com/opentracing/opentracing-java/issues/45

Supersedes https://github.com/opentracing/opentracing-java/pull/56 