### PR TITLE
support opentracing-api module in jdk 1.6

### DIFF
--- a/opentracing-api/pom.xml
+++ b/opentracing-api/pom.xml
@@ -29,6 +29,8 @@
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
+        <main.java.version>1.6</main.java.version>
+        <main.signature.artifact>java16</main.signature.artifact>
     </properties>
 
     <dependencies>

--- a/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
@@ -46,7 +46,7 @@ public interface Format<C> {
          * @see Format
          * @see Builtin#HTTP_HEADERS
          */
-        public final static Format<TextMap> TEXT_MAP = new Builtin<>();
+        public final static Format<TextMap> TEXT_MAP = new Builtin<TextMap>();
 
         /**
          * The HTTP_HEADERS format allows for HTTP-header-compatible String->String map encoding of SpanContext state
@@ -60,7 +60,7 @@ public interface Format<C> {
          * @see Format
          * @see Builtin#TEXT_MAP
          */
-        public final static Format<TextMap> HTTP_HEADERS = new Builtin<>();
+        public final static Format<TextMap> HTTP_HEADERS = new Builtin<TextMap>();
 
         /**
          * The BINARY format allows for unconstrained binary encoding of SpanContext state for Tracer.inject and
@@ -70,6 +70,6 @@ public interface Format<C> {
          * @see io.opentracing.Tracer#extract(Format, Object)
          * @see Format
          */
-        public final static Format<ByteBuffer> BINARY = new Builtin<>();
+        public final static Format<ByteBuffer> BINARY = new Builtin<ByteBuffer>();
     }
 }


### PR DESCRIPTION
The source code of opentracing-api is just interface or abstract class for OpenTracing specification. Is it necessary use jdk 1.7 to build? 
I also check the release version on `The Central Repository`, class file is also build by JDK 1.7

Many projects use opentracing.io specification in order to build trace system, which is using javaagent tech. Such as [sky-walking](https://github.com/wu-sheng/sky-walking)  (I am working on it). It's jdk level must match to target app. Also  we will support jdk 1.6, 1.7 and 1.8 .

Official opentracing-api should release on jdk 1.6. Is this look good to you?