### PR TITLE
WIP: Separate SpanContext from SpanBuilder

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -89,7 +89,7 @@ public interface Tracer {
   <C> SpanContext extract(Format<C> format, C carrier);
 
 
-  interface SpanBuilder extends SpanContext {
+  interface SpanBuilder {
 
       /**
        * A shorthand for addReference(References.CHILD_OF, parent).

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpan.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpan.java
@@ -15,16 +15,13 @@ package io.opentracing.impl;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
+
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-abstract class AbstractSpan implements Span, SpanContext {
+abstract class AbstractSpan implements Span {
 
     private String operationName;
 
@@ -34,21 +31,21 @@ abstract class AbstractSpan implements Span, SpanContext {
     private Duration duration;
     private final Map<String,Object> tags = new HashMap<>();
     private final List<LogData> logs = new ArrayList<>();
+    private SpanContext context;
 
-    AbstractSpan(String operationName ) {
-        this(operationName, Instant.now());
+    AbstractSpan(String operationName, SpanContext context) {
+        this(operationName, Instant.now(), context);
     }
 
-    AbstractSpan(String operationName, Instant start) {
+    AbstractSpan(String operationName, Instant start, SpanContext context) {
         this.operationName = operationName;
         this.start = start;
-        // TODO delegate baggage operations to context instead of holding a direct reference to underlying map
-        // this.baggage = context.baggage;
+        this.context = context;
     }
 
     @Override
     public final SpanContext context() {
-        return this;
+        return context;
     }
 
     @Override
@@ -121,7 +118,7 @@ abstract class AbstractSpan implements Span, SpanContext {
         return baggage.get(key);
     }
 
-    @Override
+    // TOOD remove
     public final Iterable<Map.Entry<String,String>> baggageItems() {
         return baggage.entrySet();
     }

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpan.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpan.java
@@ -42,6 +42,8 @@ abstract class AbstractSpan implements Span, SpanContext {
     AbstractSpan(String operationName, Instant start) {
         this.operationName = operationName;
         this.start = start;
+        // TODO delegate baggage operations to context instead of holding a direct reference to underlying map
+        // this.baggage = context.baggage;
     }
 
     @Override

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpan.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpan.java
@@ -25,19 +25,17 @@ abstract class AbstractSpan implements Span {
 
     private String operationName;
 
-    private final Map<String,String> baggage = new HashMap<>();
-
     private final Instant start;
     private Duration duration;
     private final Map<String,Object> tags = new HashMap<>();
     private final List<LogData> logs = new ArrayList<>();
-    private SpanContext context;
+    private AbstractSpanContext context;
 
-    AbstractSpan(String operationName, SpanContext context) {
+    AbstractSpan(String operationName, AbstractSpanContext context) {
         this(operationName, Instant.now(), context);
     }
 
-    AbstractSpan(String operationName, Instant start, SpanContext context) {
+    AbstractSpan(String operationName, Instant start, AbstractSpanContext context) {
         this.operationName = operationName;
         this.start = start;
         this.context = context;
@@ -109,22 +107,17 @@ abstract class AbstractSpan implements Span {
 
     @Override
     public AbstractSpan setBaggageItem(String key, String value) {
-        baggage.put(key, value);
+        context = context.setBaggageItem(key, value);
         return this;
     }
 
     @Override
     public String getBaggageItem(String key) {
-        return baggage.get(key);
-    }
-
-    // TOOD remove
-    public final Iterable<Map.Entry<String,String>> baggageItems() {
-        return baggage.entrySet();
+        return context.getBaggageItem(key);
     }
 
     public final Map<String,String> getBaggage() {
-    	return Collections.unmodifiableMap(baggage);
+    	return context.baggage;
     }
 
     @Override

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanBuilder.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanBuilder.java
@@ -27,14 +27,14 @@ import java.util.concurrent.TimeUnit;
 
 abstract class AbstractSpanBuilder implements Tracer.SpanBuilder {
 
-    protected String operationName = null;
     protected final List<Reference> references = new ArrayList<>();
+    protected final Map<String, String> baggage = new HashMap<>();
+    protected String operationName = null;
     protected Instant start = Instant.now();
 
     private final Map<String, String> stringTags = new HashMap<>();
     private final Map<String, Boolean> booleanTags = new HashMap<>();
     private final Map<String, Number> numberTags = new HashMap<>();
-    private final Map<String, String> baggage = new HashMap<>();
 
     AbstractSpanBuilder(String operationName) {
         this.operationName = operationName;

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanBuilder.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanBuilder.java
@@ -101,11 +101,6 @@ abstract class AbstractSpanBuilder implements Tracer.SpanBuilder {
     }
 
     @Override
-    public final Iterable<Map.Entry<String, String>> baggageItems() {
-        return baggage.entrySet();
-    }
-
-    @Override
     public final Span start() {
         AbstractSpan span = createSpan();
         stringTags.entrySet().stream().forEach((entry) -> { span.setTag(entry.getKey(), entry.getValue()); });

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanBuilder.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanBuilder.java
@@ -41,13 +41,7 @@ abstract class AbstractSpanBuilder implements Tracer.SpanBuilder {
 
     /** Create a Span, using the builder fields. */
     protected abstract AbstractSpan createSpan();
-
-    /** Adds an entry of the minimal set of properties required to propagate this span */
-    abstract AbstractSpanBuilder withStateItem(String key, Object value);
-
-    /** Returns true if this key+value belongs in a Span's required propagation set, otherwise it is baggage. */
-    abstract boolean isTraceState(String key, Object value);
-
+    
     @Override
     public final AbstractSpanBuilder addReference(String referenceType, SpanContext referredTo) {
         this.references.add(new Reference(referenceType, referredTo));
@@ -95,7 +89,6 @@ abstract class AbstractSpanBuilder implements Tracer.SpanBuilder {
     }
 
     public final AbstractSpanBuilder withBaggageItem(String key, String value) {
-        assert !isTraceState(key, value);
         baggage.put(key, value);
         return this;
     }

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanContext.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanContext.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
-public class AbstractSpanContext implements SpanContext {
+abstract class AbstractSpanContext implements SpanContext {
     private final AbstractTracer tracer;
     protected final Map<String, String> baggage;
     protected final Map<String, Object> traceState;
@@ -41,14 +41,10 @@ public class AbstractSpanContext implements SpanContext {
         return baggage.entrySet();
     }
 
-    SpanContext withBaggage(Map<String, String> baggage) {
-        return new AbstractSpanContext(traceState, baggage, tracer);
-    }
-
     public AbstractSpanContext setBaggageItem(String key, String value) {
         Map<String, String> newBaggage = new HashMap<>(baggage);
         newBaggage.put(key, value);
-        return new AbstractSpanContext(traceState, newBaggage, tracer);
+        return (AbstractSpanContext) tracer.createSpanContext(traceState, baggage);
     }
 
     public String getBaggageItem(String key) {

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanContext.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanContext.java
@@ -44,4 +44,14 @@ public class AbstractSpanContext implements SpanContext {
     SpanContext withBaggage(Map<String, String> baggage) {
         return new AbstractSpanContext(traceState, baggage, tracer);
     }
+
+    public AbstractSpanContext setBaggageItem(String key, String value) {
+        Map<String, String> newBaggage = new HashMap<>(baggage);
+        newBaggage.put(key, value);
+        return new AbstractSpanContext(traceState, newBaggage, tracer);
+    }
+
+    public String getBaggageItem(String key) {
+        return baggage.get(key);
+    }
 }

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanContext.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanContext.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.impl;
+
+import io.opentracing.SpanContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
+
+public class AbstractSpanContext implements SpanContext {
+    private final AbstractTracer tracer;
+    protected final Map<String, String> baggage;
+    protected final Map<String, Object> traceState;
+
+    AbstractSpanContext(Map<String, Object> traceState, AbstractTracer tracer) {
+        this(traceState, emptyMap(), tracer);
+    }
+    
+    AbstractSpanContext(Map<String, Object> traceState, Map<String, String> baggage, AbstractTracer tracer) {
+        this.traceState = unmodifiableMap(traceState);
+        this.baggage = unmodifiableMap(new HashMap<>(baggage)); 
+        this.tracer = tracer;
+    }
+
+    @Override
+    public final Iterable<Map.Entry<String, String>> baggageItems() {
+        return baggage.entrySet();
+    }
+
+    SpanContext withBaggage(Map<String, String> baggage) {
+        return new AbstractSpanContext(traceState, baggage, tracer);
+    }
+}

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractTracer.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractTracer.java
@@ -35,7 +35,7 @@ abstract class AbstractTracer implements Tracer {
 
     abstract AbstractSpanBuilder createSpanBuilder(String operationName);
     
-    abstract AbstractSpanContext createSpanContext(Map<String, Object> traceState);
+    abstract AbstractSpanContext createSpanContext(Map<String, Object> traceState, Map<String, String> baggage);
 
     @Override
     public SpanBuilder buildSpan(String operationName){

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractTracer.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractTracer.java
@@ -18,7 +18,6 @@ import io.opentracing.Tracer;
 import io.opentracing.propagation.Extractor;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.Injector;
-
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -47,7 +46,7 @@ abstract class AbstractTracer implements Tracer {
     }
 
      @Override
-    public <C> SpanBuilder extract(Format<C> format, C carrier) {
+    public <C> SpanContext extract(Format<C> format, C carrier) {
         return registry.getExtractor(format).extract(carrier);
     }
 

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractTracer.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractTracer.java
@@ -34,6 +34,8 @@ abstract class AbstractTracer implements Tracer {
     }
 
     abstract AbstractSpanBuilder createSpanBuilder(String operationName);
+    
+    abstract AbstractSpanContext createSpanContext(Map<String, Object> traceState);
 
     @Override
     public SpanBuilder buildSpan(String operationName){
@@ -60,6 +62,9 @@ abstract class AbstractTracer implements Tracer {
 
     /** @return the minimal set of properties required to propagate this span */
     abstract Map<String,Object> getTraceState(SpanContext spanContext);
+    
+    /** Returns true if this key+value belongs in a Span's required propagation set, otherwise it is baggage. */
+    abstract boolean isTraceState(String key, Object value);
 
     private static class PropagationRegistry {
 

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpan.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpan.java
@@ -16,12 +16,12 @@ package io.opentracing.impl;
 import io.opentracing.NoopSpanContext;
 import io.opentracing.Span;
 
-final class NoopSpan extends AbstractSpan implements io.opentracing.NoopSpan, NoopSpanContext {
+final class NoopSpan extends AbstractSpan implements io.opentracing.NoopSpan {
 
     static final NoopSpan INSTANCE = new NoopSpan("noop");
 
     public NoopSpan(String operationName) {
-        super(operationName);
+        super(operationName, NoopSpanContext.INSTANCE);
     }
 
     @Override

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpan.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpan.java
@@ -13,7 +13,6 @@
  */
 package io.opentracing.impl;
 
-import io.opentracing.NoopSpanContext;
 import io.opentracing.Span;
 
 final class NoopSpan extends AbstractSpan implements io.opentracing.NoopSpan {

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpanBuilder.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpanBuilder.java
@@ -25,14 +25,4 @@ final class NoopSpanBuilder extends AbstractSpanBuilder implements io.opentracin
     protected AbstractSpan createSpan() {
         return NoopSpan.INSTANCE;
     }
-
-    @Override
-    AbstractSpanBuilder withStateItem(String key, Object value) {
-        return this;
-    }
-
-    @Override
-    boolean isTraceState(String key, Object value) {
-        return false;
-    }
 }

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpanBuilder.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpanBuilder.java
@@ -13,9 +13,7 @@
  */
 package io.opentracing.impl;
 
-import io.opentracing.NoopSpanContext;
-
-final class NoopSpanBuilder extends AbstractSpanBuilder implements io.opentracing.NoopSpanBuilder, NoopSpanContext {
+final class NoopSpanBuilder extends AbstractSpanBuilder implements io.opentracing.NoopSpanBuilder {
 
     static final NoopSpanBuilder INSTANCE = new NoopSpanBuilder("noop");
 

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpanContext.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpanContext.java
@@ -13,19 +13,10 @@
  */
 package io.opentracing.impl;
 
-final class TestSpanBuilder extends AbstractSpanBuilder {
-
-    public TestSpanBuilder(String operationName) {
-        super(operationName);
-    }
-
-    @Override
-    protected AbstractSpan createSpan() {
-        return new AbstractSpan(operationName) {
-            @Override
-            public AbstractSpan setBaggageItem(String key, String value) {
-                return this;
-            }
-        };
+public class NoopSpanContext extends AbstractSpanContext {
+    public static final NoopSpanContext INSTANCE = new NoopSpanContext();
+    
+    private NoopSpanContext() {
+        super(null, null);
     }
 }

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpanContext.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopSpanContext.java
@@ -13,10 +13,12 @@
  */
 package io.opentracing.impl;
 
+import java.util.Collections;
+
 public class NoopSpanContext extends AbstractSpanContext {
     public static final NoopSpanContext INSTANCE = new NoopSpanContext();
     
     private NoopSpanContext() {
-        super(null, null);
+        super(Collections.emptyMap(), NoopTracer.INSTANCE);
     }
 }

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopTracer.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopTracer.java
@@ -26,8 +26,8 @@ final class NoopTracer extends AbstractTracer implements io.opentracing.NoopTrac
     public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {}
 
     @Override
-    public <C> SpanBuilder extract(Format<C> format, C carrier) {
-        return io.opentracing.NoopSpanBuilder.INSTANCE;
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        return NoopSpan.INSTANCE;
     }
 
     @Override

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopTracer.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopTracer.java
@@ -13,21 +13,23 @@
  */
 package io.opentracing.impl;
 
+import io.opentracing.NoopSpanContext;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
+
 import java.util.Collections;
 import java.util.Map;
 
 final class NoopTracer extends AbstractTracer implements io.opentracing.NoopTracer {
 
-    private static final NoopTracer INSTANCE = new NoopTracer();
+    static final NoopTracer INSTANCE = new NoopTracer();
 
     @Override
     public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {}
 
     @Override
     public <C> SpanContext extract(Format<C> format, C carrier) {
-        return NoopSpan.INSTANCE;
+        return NoopSpanContext.INSTANCE;
     }
 
     @Override
@@ -37,7 +39,10 @@ final class NoopTracer extends AbstractTracer implements io.opentracing.NoopTrac
     
     @Override
     AbstractSpanContext createSpanContext(Map<String, Object> traceState) {
-        return NoopSpanContext.INSTANCE;
+        // TODO Noop tracer must not fail. But NoopSpanContext is in a separate module and it cannot extend AbstractSpanContext.
+        // The best solution would be to use NoopTracer implementation which does not extend AbstractTracer - the one from
+        // opentracing-noop - and remove this one.
+        throw new UnsupportedOperationException("NoopTracer cannot create SpanContexts");
     }
 
     @Override

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopTracer.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopTracer.java
@@ -34,11 +34,19 @@ final class NoopTracer extends AbstractTracer implements io.opentracing.NoopTrac
     AbstractSpanBuilder createSpanBuilder(String operationName) {
         return NoopSpanBuilder.INSTANCE;
     }
+    
+    @Override
+    AbstractSpanContext createSpanContext(Map<String, Object> traceState) {
+        return NoopSpanContext.INSTANCE;
+    }
 
     @Override
     Map<String, Object> getTraceState(SpanContext spanContext) {
         return Collections.emptyMap();
     }
 
-
+    @Override
+    boolean isTraceState(String key, Object value) {
+        return false;
+    }
 }

--- a/opentracing-impl/src/main/java/io/opentracing/impl/NoopTracer.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/NoopTracer.java
@@ -38,7 +38,7 @@ final class NoopTracer extends AbstractTracer implements io.opentracing.NoopTrac
     }
     
     @Override
-    AbstractSpanContext createSpanContext(Map<String, Object> traceState) {
+    AbstractSpanContext createSpanContext(Map<String, Object> traceState, Map<String, String> baggage) {
         // TODO Noop tracer must not fail. But NoopSpanContext is in a separate module and it cannot extend AbstractSpanContext.
         // The best solution would be to use NoopTracer implementation which does not extend AbstractTracer - the one from
         // opentracing-noop - and remove this one.

--- a/opentracing-impl/src/main/java/io/opentracing/impl/TextMapExtractorImpl.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/TextMapExtractorImpl.java
@@ -42,6 +42,6 @@ final class TextMapExtractorImpl implements Extractor<TextMap> {
             }
         }
         
-        return tracer.createSpanContext(traceState).withBaggage(baggage);
+        return tracer.createSpanContext(traceState, baggage);
     }
 }

--- a/opentracing-impl/src/main/java/io/opentracing/impl/TextMapExtractorImpl.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/TextMapExtractorImpl.java
@@ -13,11 +13,10 @@
  */
 package io.opentracing.impl;
 
-import io.opentracing.Tracer;
-import java.util.Map;
-
+import io.opentracing.SpanContext;
 import io.opentracing.propagation.Extractor;
 import io.opentracing.propagation.TextMap;
+import java.util.Map;
 
 final class TextMapExtractorImpl implements Extractor<TextMap> {
 
@@ -28,8 +27,7 @@ final class TextMapExtractorImpl implements Extractor<TextMap> {
     }
 
     @Override
-    public Tracer.SpanBuilder extract(TextMap carrier) {
-
+    public SpanContext extract(TextMap carrier) {
         AbstractSpanBuilder builder = tracer.createSpanBuilder("extracted");
         for (Map.Entry<String, String> entry : carrier) {
             if (builder.isTraceState(entry.getKey(), entry.getValue())) {
@@ -38,7 +36,6 @@ final class TextMapExtractorImpl implements Extractor<TextMap> {
                 builder.withBaggageItem(entry.getKey(), entry.getValue());
             }
         }
-        return builder;
+        return builder.createSpan().context();
     }
-
 }

--- a/opentracing-impl/src/main/java/io/opentracing/impl/TextMapInjectorImpl.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/TextMapInjectorImpl.java
@@ -14,10 +14,9 @@
 package io.opentracing.impl;
 
 import io.opentracing.SpanContext;
-import java.util.Map;
-
 import io.opentracing.propagation.Injector;
 import io.opentracing.propagation.TextMap;
+import java.util.Map;
 
 final class TextMapInjectorImpl implements Injector<TextMap> {
 

--- a/opentracing-impl/src/main/java/io/opentracing/impl/TextMapInjectorImpl.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/TextMapInjectorImpl.java
@@ -34,7 +34,7 @@ final class TextMapInjectorImpl implements Injector<TextMap> {
             carrier.put(entry.getKey(), entry.getValue().toString());
         }
         if (baggageEnabled) {
-            for (Map.Entry<String,String> entry : ((AbstractSpan)spanContext).baggageItems()) {
+            for (Map.Entry<String,String> entry : spanContext.baggageItems()) {
                 carrier.put(entry.getKey(), entry.getValue());
             }
         }

--- a/opentracing-impl/src/main/java/io/opentracing/propagation/Extractor.java
+++ b/opentracing-impl/src/main/java/io/opentracing/propagation/Extractor.java
@@ -13,8 +13,8 @@
  */
 package io.opentracing.propagation;
 
-import io.opentracing.Tracer;
+import io.opentracing.SpanContext;
 
 public interface Extractor<C> {
-    Tracer.SpanBuilder extract(C carrier);
+    SpanContext extract(C carrier);
 }

--- a/opentracing-impl/src/test/java/io/opentracing/impl/AbstractTracerTest.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/AbstractTracerTest.java
@@ -55,7 +55,7 @@ public final class AbstractTracerTest {
         AbstractTracer instance = new TestTracerImpl();
         instance.register(Format.Builtin.TEXT_MAP, new TestTextMapInjectorImpl());
 
-        AbstractSpanContext ctx = instance.createSpanContext(Collections.singletonMap("opname", "test-inject-span"));
+        AbstractSpanContext ctx = instance.createSpanContext(Collections.singletonMap("opname", "test-inject-span"), Collections.emptyMap());
         Span span = new TestSpanImpl("test-inject-span", ctx);
         Map<String,String> map = new HashMap<>();
         TextMap carrier = new TextMapInjectAdapter(map);
@@ -140,7 +140,7 @@ public final class AbstractTracerTest {
             return new AbstractSpanBuilder(operationName) {
                 @Override
                 protected AbstractSpan createSpan() {
-                    return new TestSpanImpl(this.operationName, createSpanContext(emptyMap()));
+                    return new TestSpanImpl(this.operationName, createSpanContext(emptyMap(), baggage));
                 }
             };
         }
@@ -156,8 +156,8 @@ public final class AbstractTracerTest {
         }
 
         @Override
-        AbstractSpanContext createSpanContext(Map<String, Object> traceState) {
-            return new AbstractSpanContext(traceState, this) {};
+        AbstractSpanContext createSpanContext(Map<String, Object> traceState, Map<String, String> baggage) {
+            return new AbstractSpanContext(traceState, baggage, this) {};
         }
     }
 

--- a/opentracing-impl/src/test/java/io/opentracing/impl/AbstractTracerTest.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/AbstractTracerTest.java
@@ -122,21 +122,22 @@ public final class AbstractTracerTest {
                 protected AbstractSpan createSpan() {
                     return new TestSpanImpl(this.operationName);
                 }
-                @Override
-                boolean isTraceState(String key, Object value) {
-                    return false;
-                }
-
-                @Override
-                AbstractSpanBuilder withStateItem(String key, Object value) {
-                    throw new AssertionError("no trace state is possible");
-                }
             };
+        }
+        
+        @Override
+        boolean isTraceState(String key, Object value) {
+            return false;
         }
 
         @Override
         Map<String, Object> getTraceState(SpanContext spanContext) {
             return new HashMap<>(((AbstractSpan)spanContext).getBaggage());
+        }
+
+        @Override
+        AbstractSpanContext createSpanContext(Map<String, Object> traceState) {
+            return new AbstractSpanContext(traceState, this) {};
         }
     }
 

--- a/opentracing-impl/src/test/java/io/opentracing/impl/AbstractTracerTest.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/AbstractTracerTest.java
@@ -16,15 +16,17 @@ package io.opentracing.impl;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.Tracer.SpanBuilder;
-import io.opentracing.propagation.*;
-import org.junit.Test;
-
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMap;
+import io.opentracing.propagation.TextMapExtractAdapter;
+import io.opentracing.propagation.TextMapInjectAdapter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 
 public final class AbstractTracerTest {
@@ -73,8 +75,8 @@ public final class AbstractTracerTest {
 
         Map<String,String> map = Collections.singletonMap("garbageEntry", "garbageVal");
         TextMap carrier = new TextMapExtractAdapter(map);
-        SpanBuilder emptyResult = instance.extract(Format.Builtin.TEXT_MAP, carrier);
-        assertEquals("Should be nothing to extract", NoopSpanBuilder.INSTANCE, emptyResult);
+        SpanContext emptyResult = instance.extract(Format.Builtin.TEXT_MAP, carrier);
+        assertEquals("Should be nothing to extract", NoopSpan.INSTANCE, emptyResult);
     }
 
     /**
@@ -88,8 +90,8 @@ public final class AbstractTracerTest {
 
         Map<String,String> map = Collections.singletonMap("test-marker", "whatever");
         TextMap carrier = new TextMapExtractAdapter(map);
-        SpanBuilder result = instance.extract(Format.Builtin.TEXT_MAP, carrier);
-        assertEquals("Should find the marker", "whatever", ((TestSpanBuilder)result).operationName);
+        SpanContext result = instance.extract(Format.Builtin.TEXT_MAP, carrier);
+        assertEquals("Should find the marker", "whatever", ((AbstractSpan) result).getOperationName());
     }
 
     @Test
@@ -106,7 +108,7 @@ public final class AbstractTracerTest {
         AbstractTracer tracer = new TestTracerImpl();
         assert NoopSpan.INSTANCE == tracer.buildSpan("child").asChildOf((Span)NoopSpan.INSTANCE).start();
         assert NoopSpan.INSTANCE == tracer.buildSpan("child").asChildOf((SpanContext)NoopSpan.INSTANCE).start();
-        assert NoopSpan.INSTANCE == tracer.buildSpan("child").asChildOf(NoopSpanBuilder.INSTANCE).start();
+        assert NoopSpan.INSTANCE == tracer.buildSpan("child").asChildOf((Span) NoopSpan.INSTANCE).start();
     }
 
     final class TestTracerImpl extends AbstractTracer {

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanBuilder.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanBuilder.java
@@ -26,7 +26,7 @@ final class TestSpanBuilder extends AbstractSpanBuilder {
 
     @Override
     protected AbstractSpan createSpan() {
-        return new AbstractSpan(operationName, tracer.createSpanContext(Collections.emptyMap())) {
+        return new AbstractSpan(operationName, tracer.createSpanContext(Collections.emptyMap(), Collections.emptyMap())) {
             @Override
             public AbstractSpan setBaggageItem(String key, String value) {
                 return this;

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanBuilder.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanBuilder.java
@@ -13,15 +13,20 @@
  */
 package io.opentracing.impl;
 
+import java.util.Collections;
+
 final class TestSpanBuilder extends AbstractSpanBuilder {
 
-    public TestSpanBuilder(String operationName) {
+    private AbstractTracer tracer;
+
+    public TestSpanBuilder(String operationName, AbstractTracer tracer) {
         super(operationName);
+        this.tracer = tracer;
     }
 
     @Override
     protected AbstractSpan createSpan() {
-        return new AbstractSpan(operationName) {
+        return new AbstractSpan(operationName, tracer.createSpanContext(Collections.emptyMap())) {
             @Override
             public AbstractSpan setBaggageItem(String key, String value) {
                 return this;

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanImpl.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanImpl.java
@@ -13,11 +13,11 @@
  */
 package io.opentracing.impl;
 
-import io.opentracing.impl.AbstractSpan;
+import io.opentracing.SpanContext;
 
 public class TestSpanImpl extends AbstractSpan {
 
-    TestSpanImpl(String operationName) {
-        super(operationName);
+    TestSpanImpl(String operationName, SpanContext ctx) {
+        super(operationName, ctx);
     }
 }

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanImpl.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestSpanImpl.java
@@ -13,11 +13,9 @@
  */
 package io.opentracing.impl;
 
-import io.opentracing.SpanContext;
-
 public class TestSpanImpl extends AbstractSpan {
 
-    TestSpanImpl(String operationName, SpanContext ctx) {
+    TestSpanImpl(String operationName, AbstractSpanContext ctx) {
         super(operationName, ctx);
     }
 }

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapExtractorImpl.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapExtractorImpl.java
@@ -13,13 +13,19 @@
  */
 package io.opentracing.impl;
 
+import io.opentracing.NoopSpanContext;
 import io.opentracing.SpanContext;
 import io.opentracing.propagation.Extractor;
 import io.opentracing.propagation.TextMap;
+
+import java.util.Collections;
 import java.util.Map;
 
 final class TestTextMapExtractorImpl implements Extractor<TextMap> {
-
+    private AbstractTracer tracer;
+    public TestTextMapExtractorImpl(AbstractTracer tracer) {
+        this.tracer = tracer;
+    }
     @Override
     public SpanContext extract(TextMap carrier) {
         String marker = null;
@@ -29,6 +35,6 @@ final class TestTextMapExtractorImpl implements Extractor<TextMap> {
             }
         }
 
-        return null != marker ? new TestSpanBuilder(marker).createSpan().context() : NoopSpan.INSTANCE;
+        return null != marker ? tracer.createSpanContext(Collections.emptyMap()) : NoopSpanContext.INSTANCE;
     }
 }

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapExtractorImpl.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapExtractorImpl.java
@@ -13,23 +13,22 @@
  */
 package io.opentracing.impl;
 
-import io.opentracing.Tracer.SpanBuilder;
+import io.opentracing.SpanContext;
 import io.opentracing.propagation.Extractor;
 import io.opentracing.propagation.TextMap;
-
 import java.util.Map;
 
 final class TestTextMapExtractorImpl implements Extractor<TextMap> {
 
     @Override
-    public SpanBuilder extract(TextMap carrier) {
+    public SpanContext extract(TextMap carrier) {
         String marker = null;
-        for (Map.Entry<String,String> entry : carrier) {
+        for (Map.Entry<String, String> entry : carrier) {
             if (entry.getKey().equals("test-marker")) {
                 marker = entry.getValue();
             }
         }
 
-        return null != marker ? new TestSpanBuilder(marker) : NoopSpanBuilder.INSTANCE;
+        return null != marker ? new TestSpanBuilder(marker).createSpan().context() : NoopSpan.INSTANCE;
     }
 }

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapExtractorImpl.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapExtractorImpl.java
@@ -35,6 +35,6 @@ final class TestTextMapExtractorImpl implements Extractor<TextMap> {
             }
         }
 
-        return null != marker ? tracer.createSpanContext(Collections.emptyMap()) : NoopSpanContext.INSTANCE;
+        return null != marker ? tracer.createSpanContext(Collections.emptyMap(), Collections.emptyMap()) : NoopSpanContext.INSTANCE;
     }
 }

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapInjectorImpl.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestTextMapInjectorImpl.java
@@ -14,13 +14,13 @@
 package io.opentracing.impl;
 
 import io.opentracing.SpanContext;
-import io.opentracing.impl.AbstractSpan;
 import io.opentracing.propagation.Injector;
 import io.opentracing.propagation.TextMap;
 
 final class TestTextMapInjectorImpl implements Injector<TextMap> {
     @Override
     public void inject(SpanContext spanContext, TextMap carrier) {
-        carrier.put("test-marker", ((AbstractSpan)spanContext).getOperationName());
+        Object operationName = ((AbstractSpanContext) spanContext).traceState.get("opname");
+        carrier.put("test-marker", (String) operationName);
     }
 }

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -18,8 +18,10 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * MockTracer makes it easy to test the semantics of OpenTracing instrumentation.
@@ -163,15 +165,6 @@ public final class MockTracer implements Tracer {
         @Override
         public Span start() {
             return new MockSpan(MockTracer.this, this.operationName, this.startMicros, initialTags, this.firstParent);
-        }
-
-        @Override
-        public Iterable<Map.Entry<String, String>> baggageItems() {
-            if (firstParent == null) {
-                return Collections.EMPTY_MAP.entrySet();
-            } else {
-                return firstParent.baggageItems();
-            }
         }
     }
 }

--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpanBuilder.java
@@ -61,9 +61,4 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
     public Span start() {
         return NoopSpanImpl.INSTANCE;
     }
-
-    @Override
-    public Iterable<Map.Entry<String, String>> baggageItems() {
-        return Collections.EMPTY_MAP.entrySet();
-    }
 }

--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpanBuilder.java
@@ -13,10 +13,7 @@
  */
 package io.opentracing;
 
-import java.util.Collections;
-import java.util.Map;
-
-public interface NoopSpanBuilder extends Tracer.SpanBuilder, NoopSpanContext {
+public interface NoopSpanBuilder extends Tracer.SpanBuilder{
     static final NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
 }
 

--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpanContext.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpanContext.java
@@ -18,10 +18,10 @@ import java.util.Map;
 
 
 public interface NoopSpanContext extends SpanContext {
+    public static final NoopSpanContextImpl INSTANCE = new NoopSpanContextImpl();
 }
 
 final class NoopSpanContextImpl implements NoopSpanContext {
-    static final NoopSpanContextImpl INSTANCE = new NoopSpanContextImpl();
 
     @Override
     public Iterable<Map.Entry<String, String>> baggageItems() {

--- a/opentracing-noop/src/main/java/io/opentracing/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopTracer.java
@@ -28,7 +28,7 @@ final class NoopTracerImpl implements NoopTracer {
     public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {}
 
     @Override
-    public <C> SpanContext extract(Format<C> format, C carrier) { return NoopSpanBuilderImpl.INSTANCE; }
+    public <C> SpanContext extract(Format<C> format, C carrier) { return NoopSpanContextImpl.INSTANCE; }
 
 }
 


### PR DESCRIPTION
This is an attempt to remove SpanContext interface from SpanBuilder. See https://github.com/opentracing/opentracing-java/issues/55

Apparently it has various repercussions...

There are two places where SpanContext should be created:
1. when creating new span - based on parent span context + some span id generation strategy. Good place for that is AbstractSpanBuilder, createSpan() in particular
2. when extracting SpanContext from a carrier. It’s based on baggage and trace state keys.

One option would be to create AbstractSpanContext and then AbstractSpanContextBuilder which would have methods like withTraceState or withBaggageItem, but to keep it simple I think it’s ok to reuse just stick to **immutable AbstractSpanContext** (where mutations create new instances). 
Still, there is a need for some way to instantiate concrete subclass - that's why **I've added createSpanContext(traceState) to AbstractTracer**.

I did few other changes:
 - moved AbstractSpanBuilder.isTraceState to AbstractTracer as it was no longer needed there and there was already isTraceState in the tracer
- removed SpanBuilder.withStateItem - no longer needed

But I've run into problems with Noop implementation.
Right now there are two - one in -impl, the other in -noop. AbstractSpanBuilder asChildOf(Span parent) - requires NoopSpanBuilder to extends AbstractSpanBuilder but on the other hand AbstractSpanBuilder asChildOf tests against NoopSpanContext from opentracing-noop
which cannot depend on AbstractSpanContext (because circular dependency).

I think that it needs to be cleaned up first, especially:
- not returning Noop implementations from AbstractTracer because this forces:
  - either Noop implementations to extend abstract implementation
  - or the abstract implementation to declare interfaces as return types and then downcast
- get rid of one of noop implementations :)

(Note - the this is **not ready to merge**)

