### PR TITLE
Possible ClassCastException fix in AbstractSpanBuilder + API fixes.

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/References.java
+++ b/opentracing-api/src/main/java/io/opentracing/References.java
@@ -18,7 +18,7 @@ package io.opentracing;
  *
  * References are used by Tracer.buildSpan() to describe the relationships between Spans.
  *
- * @see io.opentracing.Tracer.SpanBuilder#addReference(Object, SpanContext)
+ * @see Tracer.SpanBuilder#addReference(String, SpanContext)
  */
 public final class References {
     private References(){}

--- a/opentracing-api/src/main/java/io/opentracing/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/Span.java
@@ -13,6 +13,7 @@
  */
 package io.opentracing;
 
+import java.io.Closeable;
 import java.util.Map;
 
 /**
@@ -20,7 +21,7 @@ import java.util.Map;
  *
  * <p>Spans are created by the {@link Tracer#buildSpan} interface.
  */
-public interface Span extends AutoCloseable {
+public interface Span extends Closeable {
     /**
      * Retrieve the associated SpanContext.
      *

--- a/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanBuilder.java
+++ b/opentracing-impl/src/main/java/io/opentracing/impl/AbstractSpanBuilder.java
@@ -70,7 +70,7 @@ abstract class AbstractSpanBuilder implements Tracer.SpanBuilder {
         if (io.opentracing.NoopSpan.class.isAssignableFrom(parent.getClass())) {
             return NoopSpanBuilder.INSTANCE;
         } else {
-            withBaggageFrom((AbstractSpan) parent);
+            withBaggageFrom(parent.context());
             return this.addReference(References.CHILD_OF, parent.context());
         }
     }
@@ -115,10 +115,10 @@ abstract class AbstractSpanBuilder implements Tracer.SpanBuilder {
     @Override
     public final Span start() {
         AbstractSpan span = createSpan();
-        stringTags.entrySet().stream().forEach((entry) -> { span.setTag(entry.getKey(), entry.getValue()); });
-        booleanTags.entrySet().stream().forEach((entry) -> { span.setTag(entry.getKey(), entry.getValue()); });
-        numberTags.entrySet().stream().forEach((entry) -> { span.setTag(entry.getKey(), entry.getValue()); });
-        baggage.entrySet().stream().forEach((entry) -> { span.setBaggageItem(entry.getKey(), entry.getValue()); });
+        stringTags.entrySet().forEach((entry) -> span.setTag(entry.getKey(), entry.getValue()));
+        booleanTags.entrySet().forEach((entry) -> span.setTag(entry.getKey(), entry.getValue()));
+        numberTags.entrySet().forEach((entry) -> span.setTag(entry.getKey(), entry.getValue()));
+        baggage.entrySet().forEach((entry) -> span.setBaggageItem(entry.getKey(), entry.getValue()));
         return span;
     }
 


### PR DESCRIPTION
- AbstractSpanBuilder did unnecessary (and unsafe!) cast to AbstractSpan that was not necessary.
- Span implements AutoCloseable which is only available since Java7 while project delcares Java6.
   Changed to Closeable which also extends AutoCloseable and doesn't declare additional methods
   so is 100% compatible and Java6 compliant.
 - Fixed broken @see link in Reference class javadoc.