### PR TITLE
Noop implementation should be in java version 1.6

### DIFF
--- a/opentracing-noop/pom.xml
+++ b/opentracing-noop/pom.xml
@@ -29,6 +29,7 @@
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
+        <main.java.version>1.6</main.java.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
As the API is explicitly defined as java 1.6, there is no reason why noop implementation should also not be build in v1.6, especially that there is nothing out there that would represent a problem for such thing. Thus I simply updated the ```pom.xml``` to overwrite the default setting from the main pom.