### PR TITLE
Make MockSpanBuilder public so it can be used in different packages

### DIFF
--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
@@ -192,7 +192,7 @@ public final class MockSpan implements Span {
          *
          * @see MockContext#withBaggageItem(String, String)
          */
-        MockContext(long traceId, long spanId, Map<String, String> baggage) {
+        public MockContext(long traceId, long spanId, Map<String, String> baggage) {
             this.baggage = baggage;
             this.traceId = traceId;
             this.spanId = spanId;

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -100,7 +100,7 @@ public class MockTracer implements Tracer {
     }
 
     @Override
-    public SpanBuilder buildSpan(String operationName) {
+    public Tracer.SpanBuilder buildSpan(String operationName) {
         return new SpanBuilder(operationName);
     }
 

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import io.opentracing.Span;
+import io.opentracing.Tracer;
 
 public class MockTracerTest {
     @Test
@@ -100,6 +101,7 @@ public class MockTracerTest {
         assertEquals("parent", parent.operationName());
         assertEquals(parent.context().spanId(), child.parentId());
         assertEquals(parent.context().traceId(), child.context().traceId());
+
     }
 
     @Test
@@ -107,7 +109,7 @@ public class MockTracerTest {
         MockTracer tracer = new MockTracer();
         long startMicros;
         {
-            MockTracer.SpanBuilder fooSpan = tracer.buildSpan("foo");
+            Tracer.SpanBuilder fooSpan = tracer.buildSpan("foo");
             Thread.sleep(2);
             startMicros = System.currentTimeMillis() * 1000;
             fooSpan.start().finish();


### PR DESCRIPTION
`MockTracer.SpanBuilder` has package level visibility. It cannot be used in different packages (`io.opentracing.mock`) . It makes it hard to test instrumentation libraries which are usually in different packages.

Q:
`MockContext` should be probably also public. It is needed when implementing custom `MockTracer.Propagator` (which a paramter in `MockTracer` public constructor).

@yurishkuro @bensigelman could you please review?