### PR TITLE
Variable size ByteBuffer implementation

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/propagation/BinaryHolder.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/BinaryHolder.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
  * @see io.opentracing.Tracer#extract(Format, Object)
  */
 public final class BinaryHolder {
-    private ByteBuffer carrier;
+    private ByteBuffer payload;
 
     /**
      * Creates a BinaryHolder with no initial size allocation.
@@ -39,25 +39,25 @@ public final class BinaryHolder {
      * Creates a BinaryHolder with provided ByteBuffer.
      * Useful for ensuring wrapped ByteBuffer has particular properties prior to Tracer.inject().
      *
-     * @param carrier The ByteBuffer to wrap within the BinaryHolder.
+     * @param payload The ByteBuffer to wrap within the BinaryHolder.
      *
      * @see Format.Builtin#BINARY_HOLDER
      */
-    public BinaryHolder(ByteBuffer carrier) {
-        this.carrier = carrier;
+    public BinaryHolder(ByteBuffer payload) {
+        this.payload = payload;
     }
 
     /**
      * If no initial ByteBuffer was allocated for the BinaryHolder, the payload becomes the wrapped ByteBuffer.
-     * Otherwise, the payload is placed in existent ByteBuffer.
+     * Otherwise, the payload is placed in existing ByteBuffer.
      *
      * @param payload a ByteBuffer.
      */
     public void addPayload(ByteBuffer payload) {
-        if (carrier == null) {
-            carrier = payload;
+        if (this.payload == null) {
+            this.payload = payload;
         } else {
-            carrier.put(payload);
+            this.payload.put(payload);
         }
     }
 
@@ -71,7 +71,7 @@ public final class BinaryHolder {
      * @see ByteBuffer#limit()
      * @see ByteBuffer#capacity()
      */
-    public ByteBuffer getCarrier() {
-        return carrier;
+    public ByteBuffer getPayload() {
+        return payload;
     }
 }

--- a/opentracing-api/src/main/java/io/opentracing/propagation/BinaryHolder.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/BinaryHolder.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.propagation;
+
+import io.opentracing.SpanContext;
+
+import java.nio.ByteBuffer;
+
+/**
+ * BinaryHolder is a built-in carrier for Tracer.inject() and Tracer.extract(). BinaryHolder allows inject to convert
+ * the SpanContext to a byte encoding without a need to know the ByteBuffer size to allocate beforehand.
+ *
+ * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
+ * @see io.opentracing.Tracer#extract(Format, Object)
+ */
+public final class BinaryHolder {
+    private ByteBuffer carrier;
+
+    /**
+     * Creates a BinaryHolder with no initial size allocation.
+     *
+     * @see Format.Builtin#BINARY_HOLDER
+     */
+    public BinaryHolder() {
+    }
+
+    /**
+     * Creates a BinaryHolder with provided ByteBuffer.
+     * Useful for ensuring wrapped ByteBuffer has particular properties prior to Tracer.inject().
+     *
+     * @param carrier The ByteBuffer to wrap within the BinaryHolder.
+     *
+     * @see Format.Builtin#BINARY_HOLDER
+     */
+    public BinaryHolder(ByteBuffer carrier) {
+        this.carrier = carrier;
+    }
+
+    /**
+     * If no initial ByteBuffer was allocated for the BinaryHolder, the payload becomes the wrapped ByteBuffer.
+     * Otherwise, the payload is placed in existent ByteBuffer.
+     *
+     * @param payload a ByteBuffer.
+     */
+    public void addPayload(ByteBuffer payload) {
+        if (carrier == null) {
+            carrier = payload;
+        } else {
+            carrier.put(payload);
+        }
+    }
+
+    /**
+     * Retrieve the wrapped ByteBuffer
+     *
+     * @return BinaryHolder's wrapped ByteBuffer; note that it is up to library implementation
+     * to validate ByteBuffer's properties before committing additional operations.
+     *
+     * @see ByteBuffer#position()
+     * @see ByteBuffer#limit()
+     * @see ByteBuffer#capacity()
+     */
+    public ByteBuffer getCarrier() {
+        return carrier;
+    }
+}

--- a/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
@@ -79,7 +79,7 @@ public interface Format<C> {
         public final static Format<ByteBuffer> BINARY = new Builtin<ByteBuffer>("BINARY");
 
         /**
-         * The BINARY_HOLDER format allows for variable binary encoding of SpanContext state for Tracer.inject and
+         * The BINARY_HOLDER format allows for variable-length binary encoding of SpanContext state for Tracer.inject and
          * Tracer.extract.
          *
          * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)

--- a/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -71,5 +71,15 @@ public interface Format<C> {
          * @see Format
          */
         public final static Format<ByteBuffer> BINARY = new Builtin<ByteBuffer>();
+
+        /**
+         * The BINARY_HOLDER format allows for variable binary encoding of SpanContext state for Tracer.inject and
+         * Tracer.extract.
+         *
+         * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
+         * @see io.opentracing.Tracer#extract(Format, Object)
+         * @see Format
+         */
+        public final static Format<BinaryHolder> BINARY_HOLDER = new Builtin<BinaryHolder>();
     }
 }

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestBinaryHolder.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestBinaryHolder.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.impl;
+
+import io.opentracing.propagation.BinaryHolder;
+import org.junit.Test;
+
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public final class TestBinaryHolder {
+
+    private byte[] randomPayload(int size) {
+        byte[] randomBytes = new byte[size];
+        new Random().nextBytes(randomBytes);
+        return randomBytes;
+    }
+
+    @Test(expected = BufferOverflowException.class)
+    public void testBinaryHolderWithInsufficientCapacity() {
+        System.out.println("binary holder with insufficient capacity");
+        BinaryHolder binaryHolder = new BinaryHolder(ByteBuffer.allocate(100));
+        ByteBuffer randomBytes51 = ByteBuffer.wrap(randomPayload(51));
+
+        for (int i = 0; i < 2; i++) {
+            binaryHolder.addPayload(randomBytes51);
+            randomBytes51.rewind();
+        }
+    }
+
+    @Test
+    public void testBinaryHolderWithSufficientCapacity() {
+        System.out.println("binary holder with sufficient capacity");
+        ByteBuffer buffer = ByteBuffer.allocate(100);
+        BinaryHolder binaryHolder = new BinaryHolder(buffer);
+        byte[] randomBytes51 = randomPayload(51);
+        binaryHolder.addPayload(ByteBuffer.wrap(randomBytes51));
+
+        ByteBuffer carrier = binaryHolder.getCarrier();
+        byte[] actual = new byte[51];
+        carrier.rewind();
+        carrier.get(actual);
+
+        assertArrayEquals(randomBytes51, actual);
+    }
+
+    @Test
+    public void testVariableBinaryHolder() {
+        System.out.println("variable binary holder");
+        BinaryHolder binaryHolder = new BinaryHolder();
+        ByteBuffer randomBytes51 = ByteBuffer.wrap(randomPayload(51));
+        binaryHolder.addPayload(randomBytes51);
+        assertEquals(randomBytes51, binaryHolder.getCarrier());
+    }
+}

--- a/opentracing-impl/src/test/java/io/opentracing/impl/TestBinaryHolder.java
+++ b/opentracing-impl/src/test/java/io/opentracing/impl/TestBinaryHolder.java
@@ -14,11 +14,12 @@
 package io.opentracing.impl;
 
 import io.opentracing.propagation.BinaryHolder;
-import org.junit.Test;
 
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.Random;
+
+import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -51,7 +52,7 @@ public final class TestBinaryHolder {
         byte[] randomBytes51 = randomPayload(51);
         binaryHolder.addPayload(ByteBuffer.wrap(randomBytes51));
 
-        ByteBuffer carrier = binaryHolder.getCarrier();
+        ByteBuffer carrier = binaryHolder.getPayload();
         byte[] actual = new byte[51];
         carrier.rewind();
         carrier.get(actual);
@@ -65,6 +66,6 @@ public final class TestBinaryHolder {
         BinaryHolder binaryHolder = new BinaryHolder();
         ByteBuffer randomBytes51 = ByteBuffer.wrap(randomPayload(51));
         binaryHolder.addPayload(randomBytes51);
-        assertEquals(randomBytes51, binaryHolder.getCarrier());
+        assertEquals(randomBytes51, binaryHolder.getPayload());
     }
 }


### PR DESCRIPTION
This patch includes an implementation of a variable-size ```BinaryHolder``` to abstract away size calculation for a ```ByteBuffer```. The ```BinaryHolder``` is flexible enough to be used as a replacement for the ```Binary``` format. For more information, see  #95.

@bensigelman, @yurishkuro, @wu-sheng, @mabn, @michaelsembwever  could you please review?