### PR TITLE
MockSpan toString method

### DIFF
--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
@@ -283,4 +283,13 @@ public final class MockSpan implements Span {
             throw ex;
         }
     }
+
+    @Override
+    public String toString() {
+        return "{" +
+                "traceId:" + context.traceId() +
+                ", spanId:" + context.spanId() +
+                ", parentId:" + parentId +
+                ", operationName:\"" + operationName + "\"}";
+    }
 }


### PR DESCRIPTION
`MockSpan#toString()` for debug purposes. It also simplifies implementation of "`LoggingTracer`"

```java
class LoggingTracer extends MockTracer {
        protected void onSpanFinished(MockSpan mockSpan) {
            System.out.println(mockSpan);
        }
    }
```

It closes https://github.com/opentracing/opentracing-java/issues/82