### PR TITLE
Change peer.port to integer.

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/tag/Tags.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/Tags.java
@@ -83,7 +83,7 @@ public final class Tags {
     /**
      * PEER_PORT records the port number of the peer.
      */
-    public static final ShortTag PEER_PORT = new ShortTag("peer.port");
+    public static final IntTag PEER_PORT = new IntTag("peer.port");
 
     /**
      * SAMPLING_PRIORITY determines the priority of sampling this Span.


### PR DESCRIPTION
Set `peer.port` as a short, is not right. As mentioned #113 , in Java, short is -32768 to 32767, but in network world, port is 0 to 65535. 