### PR TITLE
WIP: in-process propagation resolves opentracing/specification#23

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/Span.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,6 +22,9 @@ import java.util.Map;
  * <p>Spans are created by the {@link Tracer#buildSpan} interface.
  */
 public interface Span extends Closeable {
+
+    SpanManager.Visibility visibility();
+
     /**
      * Retrieve the associated SpanContext.
      *
@@ -42,6 +45,8 @@ public interface Span extends Closeable {
     void finish();
 
     /**
+     * Deactivates spans from spanManager.
+     *
      * Sets an explicit end timestamp and records the span.
      *
      * <p>With the exception of calls to Span.context(), this should be the last call made to the span instance, and to

--- a/opentracing-api/src/main/java/io/opentracing/SpanManager.java
+++ b/opentracing-api/src/main/java/io/opentracing/SpanManager.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing;
+
+/**
+ * @author Pavol Loffay
+ */
+public interface SpanManager {
+
+    /**
+     * @param span span to bundle into visibility, there is always only one visibility per span
+     * @return visibility
+     */
+    Visibility bundle(Span span);
+
+    /**
+     * @return not finished active span or null
+     */
+    VisibilityContext active();
+
+    interface Visibility {
+        /**
+         * @return visibility context which is used to activate/deactivate span
+         */
+        VisibilityContext capture();
+
+        /**
+         * @return associated span or null if visibility is marked as finished.
+         */
+        Span span();
+        /**
+         * @return always spanContext
+         */
+        SpanContext context();
+
+        /**
+         * Mark associated span as finished.
+         *
+         * Should be called by {@link Span#finish()} or directly if one does not want to expose span.
+         * This method should be idempotent.
+         *
+         * review note: reverse operation should not be allowed.
+         */
+        void hideSpan();
+    }
+
+    interface VisibilityContext {
+        /**
+         * on/activate - {@link SpanManager#active()} will return this object.
+         */
+        VisibilityContext on();
+        /**
+         * off/deactivate - {@link SpanManager#active()} will not return this object.
+         */
+        VisibilityContext off();
+
+        Visibility visibility();
+    }
+}

--- a/opentracing-api/src/main/java/io/opentracing/ThreadLocalSpanManager.java
+++ b/opentracing-api/src/main/java/io/opentracing/ThreadLocalSpanManager.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author Pavol Loffay
+ */
+public class ThreadLocalSpanManager implements SpanManager {
+
+    private final ThreadLocal<SimpleLinkedVisibilityContext> activeContext = new ThreadLocal<SimpleLinkedVisibilityContext>();
+
+    @Override
+    public Visibility bundle(Span span) {
+        return span.visibility() == null ? new SimpleVisibility(span) : span.visibility();
+    }
+
+    @Override
+    public SimpleLinkedVisibilityContext active() {
+        return activeContext.get();
+    }
+
+    class SimpleVisibility implements Visibility {
+        private final Span span;
+        private AtomicBoolean hideSpan = new AtomicBoolean(false);
+
+        public SimpleVisibility(Span span) {
+            this.span = span;
+        }
+
+        @Override
+        public Span span() {
+            return hideSpan.get() ? null : span;
+        }
+
+        @Override
+        public SpanContext context() {
+            return span.context();
+        }
+
+        @Override
+        public SimpleLinkedVisibilityContext capture() {
+            return new SimpleLinkedVisibilityContext(this);
+        }
+
+        @Override
+        public void hideSpan() {
+            hideSpan.set(true);
+        }
+    }
+
+    class SimpleLinkedVisibilityContext implements SpanManager.VisibilityContext {
+
+        private final SimpleVisibility visibility;
+        private SimpleLinkedVisibilityContext previous;
+
+        public SimpleLinkedVisibilityContext(SimpleVisibility visibility) {
+            this.visibility = visibility;
+        }
+
+        @Override
+        public SimpleLinkedVisibilityContext on() {
+            previous = activeContext.get();
+            activeContext.set(this);
+            return this;
+        }
+
+        @Override
+        public SimpleLinkedVisibilityContext off() {
+            if (this == activeContext.get()) {
+                activeContext.set(previous);
+            }
+            // else should not happen
+
+            return this;
+        }
+
+        @Override
+        public Visibility visibility() {
+            return visibility;
+        }
+    }
+}

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -20,6 +20,9 @@ import io.opentracing.propagation.Format;
  */
 public interface Tracer {
 
+    // span could be directly returned
+    SpanManager spanManager();
+
     /**
      * Return a new SpanBuilder for a Span with the given `operationName`.
      *
@@ -113,6 +116,8 @@ public interface Tracer {
          */
         SpanBuilder addReference(String referenceType, SpanContext referencedContext);
 
+        SpanBuilder asRoot();
+
         /** Same as {@link Span#setTag(String, String)}, but for the span being built. */
         SpanBuilder withTag(String key, String value);
 
@@ -127,6 +132,5 @@ public interface Tracer {
 
         /** Returns the started Span. */
         Span start();
-
     }
 }

--- a/opentracing-mock/pom.xml
+++ b/opentracing-mock/pom.xml
@@ -36,6 +36,26 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>opentracing-api</artifactId>
         </dependency>
+
+        <!-- for MDC demo will go away -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.23</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.23</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/opentracing-mock/src/test/java/io/opentracing/spanmanager/SpanManagerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/spanmanager/SpanManagerTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.spanmanager;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.spanmanager.concurrent.TracedExecutorService;
+
+/**
+ * @author Pavol Loffay
+ */
+public class SpanManagerTest {
+
+    private final MockTracer mockTracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
+
+    @Before
+    public void before() {
+        mockTracer.reset();
+    }
+
+    @Test
+    public void test() {
+        MockSpan root = mockTracer.buildSpan("root").start();
+        Assert.assertTrue(mockTracer.spanManager().active() == null);
+
+        root.visibility().capture().on();
+        Assert.assertEquals(root, mockTracer.spanManager().active().visibility().span());
+
+        MockSpan child = mockTracer.buildSpan("child").start();
+
+        child.finish();
+        root.finish();
+
+        Assert.assertEquals(root.context().spanId(), child.parentId());
+    }
+
+    @Test
+    public void testTracedRunnable() throws ExecutionException, InterruptedException {
+        {
+            ExecutorService executorService = new TracedExecutorService(Executors.newFixedThreadPool(500),
+                    mockTracer.spanManager());
+
+            MockSpan root = mockTracer.buildSpan("root").start();
+            root.visibility().capture().on();
+
+            executorService.submit(new Runnable() {
+                @Override
+                public void run() {
+                    Assert.assertNotNull(mockTracer.spanManager().active().visibility().span());
+
+                    mockTracer.buildSpan("child")
+                            .start()
+                            .finish();
+                }
+            });
+
+            executorService.shutdown();
+            executorService.awaitTermination(10, TimeUnit.SECONDS);
+            root.finish();
+        }
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        Assert.assertEquals(2, mockSpans.size());
+        Assert.assertEquals(mockSpans.get(0).parentId(), mockSpans.get(1).context().spanId());
+    }
+}

--- a/opentracing-mock/src/test/java/io/opentracing/spanmanager/concurrent/TracedCallable.java
+++ b/opentracing-mock/src/test/java/io/opentracing/spanmanager/concurrent/TracedCallable.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.spanmanager.concurrent;
+
+import java.util.concurrent.Callable;
+
+import io.opentracing.SpanManager;
+
+/**
+ * @author Pavol Loffay
+ */
+public class TracedCallable<V> implements Callable<V>{
+
+    private Callable<V> wrapped;
+    private SpanManager.VisibilityContext visibility;
+
+    public TracedCallable(Callable<V> wrapped, SpanManager spanManager) {
+        this.wrapped = wrapped;
+        this.visibility = spanManager.active().visibility().capture();
+
+    }
+
+    @Override
+    public V call() throws Exception {
+        visibility.on();
+       try {
+            return wrapped.call();
+        } finally {
+            visibility.off();
+        }
+    }
+}

--- a/opentracing-mock/src/test/java/io/opentracing/spanmanager/concurrent/TracedExecutorService.java
+++ b/opentracing-mock/src/test/java/io/opentracing/spanmanager/concurrent/TracedExecutorService.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.spanmanager.concurrent;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.opentracing.SpanManager;
+
+/**
+ * @author Pavol Loffay
+ */
+public class TracedExecutorService implements ExecutorService {
+
+    private ExecutorService wrapped;
+    private SpanManager spanManager;
+
+    public TracedExecutorService(ExecutorService wrapped, SpanManager spanManager) {
+        this.wrapped = wrapped;
+        this.spanManager = spanManager;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return wrapped.isTerminated();
+    }
+
+    @Override
+    public void shutdown() {
+        wrapped.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return wrapped.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return wrapped.isShutdown();
+    }
+
+    @Override
+    public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException {
+        return wrapped.awaitTermination(l, timeUnit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> callable) {
+        return wrapped.submit(new TracedCallable<T>(callable, spanManager));
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable runnable, T t) {
+        return wrapped.submit(new TracedRunnable(runnable, spanManager), t);
+    }
+
+    @Override
+    public Future<?> submit(Runnable runnable) {
+        return wrapped.submit(new TracedRunnable(runnable, spanManager));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> collection) throws InterruptedException {
+        return wrapped.invokeAll(tracedCallables(collection));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> collection, long l, TimeUnit timeUnit)
+            throws InterruptedException {
+        return wrapped.invokeAll(tracedCallables(collection), l, timeUnit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> collection)
+            throws InterruptedException, ExecutionException {
+        return wrapped.invokeAny(tracedCallables(collection));
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> collection, long l, TimeUnit timeUnit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return wrapped.invokeAny(tracedCallables(collection), l, timeUnit);
+    }
+
+    @Override
+    public void execute(Runnable runnable) {
+        wrapped.submit(new TracedRunnable(runnable, spanManager));
+    }
+
+    private <T> Collection<? extends Callable<T>> tracedCallables(Collection<? extends Callable<T>> callables) {
+        List<Callable<T>> tracedCallables = new ArrayList<Callable<T>>(callables.size());
+
+        for (Callable<T> callable: callables) {
+            tracedCallables.add(new TracedCallable<T>(callable, spanManager));
+        }
+
+        return tracedCallables;
+    }
+}

--- a/opentracing-mock/src/test/java/io/opentracing/spanmanager/concurrent/TracedRunnable.java
+++ b/opentracing-mock/src/test/java/io/opentracing/spanmanager/concurrent/TracedRunnable.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.spanmanager.concurrent;
+
+import io.opentracing.SpanManager;
+
+/**
+ * @author Pavol Loffay
+ */
+public class TracedRunnable implements Runnable {
+
+    private Runnable wrapped;
+    private SpanManager.VisibilityContext visibility;
+
+    public TracedRunnable(Runnable wrapped, SpanManager spanManager) {
+        this.wrapped = wrapped;
+        this.visibility = spanManager.active().visibility().capture();
+    }
+
+    @Override
+    public void run() {
+        visibility.on();
+        try {
+                wrapped.run();
+        } finally {
+            visibility.off();
+        }
+    }
+}

--- a/opentracing-mock/src/test/java/io/opentracing/spanmanager/mdc/MDCDemo.java
+++ b/opentracing-mock/src/test/java/io/opentracing/spanmanager/mdc/MDCDemo.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.spanmanager.mdc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.MDC;
+
+import io.opentracing.Span;
+import io.opentracing.SpanManager;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.spanmanager.concurrent.TracedExecutorService;
+
+/**
+ * @author Pavol Loffay
+ */
+public class MDCDemo {
+    static {
+        org.apache.log4j.BasicConfigurator.configure();
+    }
+    private static final Logger logger = org.slf4j.LoggerFactory.getLogger(MDCDemo.class.getSimpleName());
+    private static final MockTracer tracer = new MockTracer(MockTracer.Propagator.PRINTER, new MDCThreadLocalSpanManager());
+
+    public void singleSpan() {
+        tracer.buildSpan("single").start().finish();
+    }
+
+    public void parentWithChild() throws Exception {
+        Span parent = tracer.buildSpan("parent").start();
+        SpanManager.VisibilityContext parentVisibility = parent.visibility().capture().on();
+        // The child will automatically know about the parent.
+        tracer.buildSpan("child")
+                .start()
+                .finish();
+        parentVisibility.off();
+        parent.finish();
+    }
+
+    public void asyncSpans() throws Exception {
+        final ExecutorService otExecutor = new TracedExecutorService(Executors.newFixedThreadPool(100), tracer.spanManager());
+
+        // Hacky lists of futures we wait for before exiting async Spans.
+        List<Future<?>> futures = new ArrayList<>();
+        final List<Future<?>> subfutures = new ArrayList<>();
+
+        // Create a parent Continuation for all of the async activity.
+        Span parent = tracer.buildSpan("asyncParent").start();
+        SpanManager.VisibilityContext parentVisibility = parent.visibility().capture().on();
+
+        // Create 10 async children.
+        for (int i = 0; i < 10; i++) {
+            final int j = i;
+            MDC.put("parent_number", String.valueOf(j));
+            futures.add(otExecutor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    final Span childSpan = tracer.buildSpan("child_" + j).start();
+                    childSpan.visibility().capture().on();
+
+                    try {
+                        Thread.currentThread().sleep(1000);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                    tracer.spanManager().active().visibility().span().log("awoke");
+                    subfutures.add(otExecutor.submit(new Runnable() {
+                        @Override
+                        public void run() {
+                            Span active = tracer.spanManager().active().visibility().span();
+                            active.log("awoke again");
+                            System.out.println(String.format("j=%d, MDC parent number: %s, MDC map: %s",
+                                    j, MDC.get("parent_number"), MDC.getCopyOfContextMap()));
+                            // Create a grandchild for each child... note that we don't *need* to use the
+                            // Continuation mechanism.
+                            Span grandchild = tracer.buildSpan("grandchild_" + j).start();
+                            grandchild.finish();
+                            childSpan.finish();
+                        }
+                    }));
+                }
+            }));
+        }
+
+        // Hacky cleanup... grossness has nothing to do with OT :)
+        for (Future<?> f : futures) {
+            f.get();
+        }
+        for (Future<?> f : subfutures) {
+            f.get();
+        }
+
+        parent.finish();
+        parentVisibility.off();
+
+        otExecutor.shutdown();
+        otExecutor.awaitTermination(3, TimeUnit.SECONDS);
+    }
+
+    public static void main(String[] args) throws Exception {
+        MDC.put("method", "main");
+
+        MDCDemo demo = new MDCDemo();
+        demo.singleSpan();
+        demo.parentWithChild();
+        demo.asyncSpans();
+
+        // Print out all mock-Spans
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+        for (MockSpan span : finishedSpans) {
+            logger.info("finished Span '{}', span.log: {} ", span, logEntryToString(span.logEntries()));
+        }
+    }
+
+    public static String logEntryToString(List<MockSpan.LogEntry> logEntries) {
+        StringBuilder sb = new StringBuilder();
+        for (MockSpan.LogEntry logEntry: logEntries) {
+            sb.append(logEntry.fields());
+        }
+        return sb.length() == 0 ? "{}" : sb.toString();
+    }
+}
+

--- a/opentracing-mock/src/test/java/io/opentracing/spanmanager/mdc/MDCThreadLocalSpanManager.java
+++ b/opentracing-mock/src/test/java/io/opentracing/spanmanager/mdc/MDCThreadLocalSpanManager.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.spanmanager.mdc;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.MDC;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.SpanManager;
+
+/**
+ * @author Pavol Loffay
+ */
+public class MDCThreadLocalSpanManager implements SpanManager {
+
+    private final ThreadLocal<MDCLinkedVisibilityContext> activeContext = new ThreadLocal<>();
+
+    @Override
+    public Visibility bundle(Span span) {
+        return span.visibility() == null ? new MDCVisibility(span) : span.visibility();
+    }
+
+    @Override
+    public VisibilityContext active() {
+        return activeContext.get();
+    }
+
+    class MDCVisibility implements Visibility {
+        private final Span span;
+        private AtomicBoolean hideSpan = new AtomicBoolean(false);
+
+        public MDCVisibility(Span span) {
+            this.span = span;
+        }
+
+        @Override
+        public MDCLinkedVisibilityContext capture() {
+            return new MDCLinkedVisibilityContext(this);
+        }
+
+        @Override
+        public Span span() {
+            return hideSpan.get() ? null : span;
+        }
+
+        @Override
+        public SpanContext context() {
+            return span.context();
+        }
+
+        @Override
+        public void hideSpan() {
+            hideSpan.set(true);
+        }
+    }
+
+    class MDCLinkedVisibilityContext implements VisibilityContext {
+        private final MDCVisibility visibility;
+        private MDCLinkedVisibilityContext previous;
+        private Map<String, String> mdcContext;
+
+        public MDCLinkedVisibilityContext(MDCVisibility visibility) {
+            this.visibility = visibility;
+            this.mdcContext = MDC.getCopyOfContextMap();
+        }
+
+        @Override
+        public MDCLinkedVisibilityContext on() {
+            MDC.setContextMap(mdcContext);
+            previous = activeContext.get();
+            activeContext.set(this);
+            return this;
+        }
+
+        @Override
+        public MDCLinkedVisibilityContext off() {
+            if (this == activeContext.get()) {
+                activeContext.set(previous);
+            }
+            // else should not happen
+
+            return this;
+        }
+
+        @Override
+        public Visibility visibility() {
+            return visibility;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
 
     <modules>
         <module>opentracing-api</module>
-        <module>opentracing-noop</module>
-        <module>opentracing-impl</module>
+        <!--<module>opentracing-noop</module>-->
+        <!--<module>opentracing-impl</module>-->
         <module>opentracing-mock</module>
     </modules>
 


### PR DESCRIPTION
Here is my minimal POC for in-process propagation #23.  

It is a permutation of  #111 and #115 with slightly different ideas:
* span should be only finished with `span.finish()`
* span manager should not expose finished span, spanContext always, if there is any..
* span can be activated but "hidden" and only exposed spanContext

What is added/changed:
* `SpanBuilder` automatically adds parent span, `childOf` if span is not finished, `followsFrom` if active span is finished/hidden.
* `Span.finish()` hides span from spanManager
* `Span` is associated to object called `Visibility` and vice versa e.g. `span.visibility()` and `visibility.span()`
* `VisibilityContext vc = Visibility.capture()` and `Visibility v = VisibilityContext.visibility()` more in code :octocat: 
 
Working implementation is done only for `MockTracer` along with some examples/tests including MDC demo from @bhs.  

It is a minimal implementation with no helper methods like `SpanBuilder.startAndActivate()`, `Span.finishAndDeactivate()`. Please focus on the concept itself. Anyways we should think of better names for `Visibility` and `VisibilityContext`... 

cc @yurishkuro  @tedsuo @adriancole @mabn @michaelsembwever @objectiser @wu-sheng @sjoerdtalsma  