### PR TITLE
Add toString() to no-op implementations.

### DIFF
--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpan.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -69,6 +69,9 @@ final class NoopSpanImpl implements NoopSpan {
 
     @Override
     public Span setOperationName(String operationName) { return this; }
+
+    @Override
+    public String toString() { return NoopSpan.class.getSimpleName(); }
 
 }
 

--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpanBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -66,4 +66,7 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
     public Iterable<Map.Entry<String, String>> baggageItems() {
         return Collections.EMPTY_MAP.entrySet();
     }
+
+    @Override
+    public String toString() { return NoopSpanBuilder.class.getSimpleName(); }
 }

--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpanContext.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpanContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,5 +27,8 @@ final class NoopSpanContextImpl implements NoopSpanContext {
     public Iterable<Map.Entry<String, String>> baggageItems() {
         return Collections.emptyList();
     }
+
+    @Override
+    public String toString() { return NoopSpanContext.class.getSimpleName(); }
 
 }

--- a/opentracing-noop/src/main/java/io/opentracing/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopTracer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -29,6 +29,9 @@ final class NoopTracerImpl implements NoopTracer {
 
     @Override
     public <C> SpanContext extract(Format<C> format, C carrier) { return NoopSpanBuilderImpl.INSTANCE; }
+
+    @Override
+    public String toString() { return NoopTracer.class.getSimpleName(); }
 
 }
 


### PR DESCRIPTION
The [GlobalTracer PR](https://github.com/opentracing/opentracing-java/pull/109/commits/dc3550b7027627e295776be27387c6b1d1ee5a44) added its delegate tracer to the toString representation which is initially the NoopTracer.
 The standard Java toString is the fully qualified classname (i.e. `io.opentracing.NoopSpanImpl`) followed by its hashcode (which is irrelevant for a singleton).
 Therefore I suggest using `NoopSpan`, `NoopSpanBuilder`, `NoopSpanContext` and `NoopTracer` as their toString() representations.