### PR TITLE
Define tag SAMPLING_PRIORITY as an integer

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/tag/ShortTag.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/ShortTag.java
@@ -13,6 +13,7 @@
  */
 package io.opentracing.tag;
 
+@Deprecated
 public class ShortTag extends AbstractTag<Short> {
     public ShortTag(String key) {
         super(key);

--- a/opentracing-api/src/main/java/io/opentracing/tag/ShortTag.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/ShortTag.java
@@ -13,6 +13,9 @@
  */
 package io.opentracing.tag;
 
+/**
+ * @deprecated use {@link IntTag} instead.
+ */
 @Deprecated
 public class ShortTag extends AbstractTag<Short> {
     public ShortTag(String key) {

--- a/opentracing-api/src/main/java/io/opentracing/tag/Tags.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/Tags.java
@@ -88,7 +88,7 @@ public final class Tags {
     /**
      * SAMPLING_PRIORITY determines the priority of sampling this Span.
      */
-    public static final ShortTag SAMPLING_PRIORITY = new ShortTag("sampling.priority");
+    public static final IntTag SAMPLING_PRIORITY = new IntTag("sampling.priority");
 
     /**
      * SPAN_KIND hints at the relationship between spans, e.g. client/server.


### PR DESCRIPTION
It is inconvenient to use `short` for this. It's a breaking change but I think it's cleaner/easier to use `integer`.

Spec defines it as an `integer` https://github.com/opentracing/specification/blob/master/semantic_conventions.yaml#L26