### PR TITLE
Make javadoc work and update license headers

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/SpanContext.java
+++ b/opentracing-api/src/main/java/io/opentracing/SpanContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@ import java.util.Map;
  *
  * SpanContext is logically divided into two pieces: (1) the user-level "Baggage" that propagates across Span
  * boundaries and (2) any Tracer-implementation-specific fields that are needed to identify or otherwise contextualize
- * the associated Span instance (e.g., a <trace_id, span_id, sampled> tuple).
+ * the associated Span instance (e.g., a &lt;trace_id, span_id, sampled&gt; tuple).
  *
  * @see Span#setBaggageItem(String, String)
  * @see Span#getBaggageItem(String)

--- a/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
@@ -42,8 +42,8 @@ public interface Format<C> {
         }
 
         /**
-         * The TEXT_MAP format allows for arbitrary String->String map encoding of SpanContext state for Tracer.inject
-         * and Tracer.extract.
+         * The TEXT_MAP format allows for arbitrary String-&gt;String map encoding of SpanContext state for
+         * Tracer.inject and Tracer.extract.
          *
          * Unlike HTTP_HEADERS, the builtin TEXT_MAP format expresses no constraints on keys or values.
          *
@@ -55,7 +55,7 @@ public interface Format<C> {
         public final static Format<TextMap> TEXT_MAP = new Builtin<TextMap>("TEXT_MAP");
 
         /**
-         * The HTTP_HEADERS format allows for HTTP-header-compatible String->String map encoding of SpanContext state
+         * The HTTP_HEADERS format allows for HTTP-header-compatible String-&gt;String map encoding of SpanContext state
          * for Tracer.inject and Tracer.extract.
          *
          * I.e., keys written to the TextMap MUST be suitable for HTTP header keys (which are poorly defined but

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapExtractAdapter.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapExtractAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,8 +21,8 @@ import java.util.Map;
 /**
  * A TextMap carrier for use with Tracer.extract() ONLY (it has no mutating methods).
  *
- * Note that the TextMap interface can be made to wrap around arbitrary data types (not just Map<String, String> as
- * illustrated here).
+ * Note that the TextMap interface can be made to wrap around arbitrary data types (not just Map&lt;String, String&gt;
+ * as illustrated here).
  *
  * @see Tracer#extract(Format, Object)
  */

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInjectAdapter.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInjectAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,8 +22,8 @@ import java.util.Map;
 /**
  * A TextMap carrier for use with Tracer.inject() ONLY (it has no read methods).
  *
- * Note that the TextMap interface can be made to wrap around arbitrary data types (not just Map<String, String> as
- * illustrated here).
+ * Note that the TextMap interface can be made to wrap around arbitrary data types (not just Map&lt;String, String&gt;
+ * as illustrated here).
  *
  * @see Tracer#inject(SpanContext, Format, Object)
  */


### PR DESCRIPTION
Carving this out of #115 to reduce noise in the diff per @yurishkuro's request.