### PR TITLE
Added SpanUtils: utility methods intended to help instrumenters follow the semantic conventions

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Field.java
+++ b/opentracing-api/src/main/java/io/opentracing/Field.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing;
+
+/**
+ * The following log fields are recommended for instrumentors who are trying to capture more
+ * information about a logged event. Tracers may expose additional features based on these
+ * standardized data points.
+ *
+ * @see <a href="https://github.com/opentracing/specification/blob/master/semantic_conventions.md">https://github.com/opentracing/specification/blob/master/semantic_conventions.md</a>
+ */
+public enum Field {
+    /**
+     * A stable identifier for some notable moment in the lifetime of a Span. For instance, a mutex
+     * lock acquisition or release or the sorts of lifetime events in a browser page load described
+     * in the Performance.timing specification. E.g., from Zipkin, "cs", "sr", "ss", or "cr". Or,
+     * more generally, "initialized" or "timed out". For errors, "error"
+     */
+    EVENT("event"),
+
+    /**
+     * A concise, human-readable, one-line message explaining the event. E.g., "Could not connect
+     * to backend", "Cache invalidation succeeded"
+     */
+    MESSAGE("message"),
+
+    /**
+     * The type or "kind" of an error (only for event="error" logs). E.g., "Exception", "OSError"
+     */
+    ERROR_KIND("error.kind"),
+
+    /**
+     * The actual Throwable/Exception/Error object instance itself. E.g., A java.lang.UnsupportedOperationException instance
+     */
+    ERROR_OBJECT("error.object");
+
+    private final String key;
+
+    Field(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("Key must not be null.");
+        }
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/opentracing-api/src/main/java/io/opentracing/FieldKeys.java
+++ b/opentracing-api/src/main/java/io/opentracing/FieldKeys.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing;
+
+/**
+ * The following log fields are recommended for instrumentors who are trying to capture more
+ * information about a logged event. Tracers may expose additional features based on these
+ * standardized data points.
+ *
+ * @see <a href="https://github.com/opentracing/specification/blob/master/semantic_conventions.md">https://github.com/opentracing/specification/blob/master/semantic_conventions.md</a>
+ */
+public class FieldKeys {
+    private FieldKeys() {
+    }
+
+    /**
+     * A stable identifier for some notable moment in the lifetime of a Span. For instance, a mutex
+     * lock acquisition or release or the sorts of lifetime events in a browser page load described
+     * in the Performance.timing specification. E.g., from Zipkin, "cs", "sr", "ss", or "cr". Or,
+     * more generally, "initialized" or "timed out". For errors, "error"
+     */
+    public static final String EVENT = "event";
+
+    /**
+     * A concise, human-readable, one-line message explaining the event. E.g., "Could not connect
+     * to backend", "Cache invalidation succeeded"
+     */
+    public static final String MESSAGE = "message";
+
+    /**
+     * The type or "kind" of an error (only for event="error" logs). E.g., "Exception", "OSError"
+     */
+    public static final String ERROR_KIND = "error.kind";
+
+    /**
+     * The actual Throwable/Exception/Error object instance itself. E.g., A java.lang.UnsupportedOperationException instance
+     */
+    public static final String ERROR_OBJECT = "error.object";
+}

--- a/opentracing-util/src/main/java/io/opentracing/util/SpanUtils.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/SpanUtils.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides convenience methods for logging and tagging spans.
+ *
+ * Follows conventions defined in https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+ */
+public class SpanUtils {
+    private SpanUtils() {
+    }
+
+    /**
+     * Tags the span as error=true and logs the occurrence of any Throwable (including all appropriate fields).
+     *
+     * @param span the span on which the error should be tagged/logged
+     * @param t throwable which will be included on the log entry including stacktrace
+     * @param message message for the log entry.
+     */
+    public static void logException(Span span, Throwable t, String message) {
+        Map<String, Object> fields = new HashMap<String, Object>();
+        fields.put("error.kind", "Exception");
+        fields.put("error.object", t);
+        fields.put("event", "error");
+        fields.put("message", message);
+        fields.put("stack", getStacktraceAsString(t));
+
+        span.setTag(Tags.ERROR.getKey(), true);
+        span.log(fields);
+    }
+
+    private static String getStacktraceAsString(Throwable t) {
+        StringWriter stackWriter = new StringWriter();
+        t.printStackTrace(new PrintWriter(stackWriter));
+        return stackWriter.toString();
+    }
+}


### PR DESCRIPTION
I've just begun instrumenting a set of Java services that interact using HTTP/REST and Kafka. We're using OT-api with a Zipkin backend. I'm new to every aspect of this (this is even my first PR); I'm sure there are ways this could be better, but please be gentle. :)

In short order, I found myself writing code that seemed broadly useful. I asked on Gitter and was told that this was a good idea and I should submit a PR. And so:

I've created SpanUtils, a first stab at a set (currently of size 1) of utility methods intended to help instrumenters follow the semantic conventions.