### PR TITLE
Force all years to 2017

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ If you are adding a new file it should have a header like below. This can be aut
 
 ```
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-api/src/main/java/io/opentracing/References.java
+++ b/opentracing-api/src/main/java/io/opentracing/References.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMap.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-api/src/test/java/io/opentracing/tag/BooleanTagTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/tag/BooleanTagTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-api/src/test/java/io/opentracing/tag/IntTagTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/tag/IntTagTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-api/src/test/java/io/opentracing/tag/ShortTagTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/tag/ShortTagTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-api/src/test/java/io/opentracing/tag/StringTagTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/tag/StringTagTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-noop/src/main/java/io/opentracing/NoopTracerFactory.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopTracerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenTracing Authors
+ * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
The license plugin runs locally (and ran on updates to PR #115) but isn't working now that it's merged. This should resolve that.