### PR TITLE
Change copyright comment in java files from /** */ style to /* */.

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/ActiveSpan.java
+++ b/opentracing-api/src/main/java/io/opentracing/ActiveSpan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/ActiveSpanSource.java
+++ b/opentracing-api/src/main/java/io/opentracing/ActiveSpanSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/BaseSpan.java
+++ b/opentracing-api/src/main/java/io/opentracing/BaseSpan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/References.java
+++ b/opentracing-api/src/main/java/io/opentracing/References.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/Span.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -12,9 +12,6 @@
  * the License.
  */
 package io.opentracing;
-
-import java.io.Closeable;
-import java.util.Map;
 
 /**
  * Represents an in-flight Span that's <strong>manually propagated</strong> within the given process. Most of

--- a/opentracing-api/src/main/java/io/opentracing/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/Span.java
@@ -13,6 +13,9 @@
  */
 package io.opentracing;
 
+import java.io.Closeable;
+import java.util.Map;
+
 /**
  * Represents an in-flight Span that's <strong>manually propagated</strong> within the given process. Most of
  * the API lives in {@link BaseSpan}.

--- a/opentracing-api/src/main/java/io/opentracing/SpanContext.java
+++ b/opentracing-api/src/main/java/io/opentracing/SpanContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMap.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -14,8 +14,8 @@
 package io.opentracing.propagation;
 
 import io.opentracing.SpanContext;
-import java.util.Iterator;
 
+import java.util.Iterator;
 import java.util.Map;
 
 /**

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMap.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMap.java
@@ -14,8 +14,8 @@
 package io.opentracing.propagation;
 
 import io.opentracing.SpanContext;
-
 import java.util.Iterator;
+
 import java.util.Map;
 
 /**

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapExtractAdapter.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapExtractAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -14,8 +14,8 @@
 package io.opentracing.propagation;
 
 import io.opentracing.Tracer;
-import java.util.Iterator;
 
+import java.util.Iterator;
 import java.util.Map;
 
 /**

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapExtractAdapter.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapExtractAdapter.java
@@ -14,8 +14,8 @@
 package io.opentracing.propagation;
 
 import io.opentracing.Tracer;
-
 import java.util.Iterator;
+
 import java.util.Map;
 
 /**

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInjectAdapter.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInjectAdapter.java
@@ -15,8 +15,8 @@ package io.opentracing.propagation;
 
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-
 import java.util.Iterator;
+
 import java.util.Map;
 
 /**

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInjectAdapter.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInjectAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -15,8 +15,8 @@ package io.opentracing.propagation;
 
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import java.util.Iterator;
 
+import java.util.Iterator;
 import java.util.Map;
 
 /**

--- a/opentracing-api/src/main/java/io/opentracing/tag/AbstractTag.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/AbstractTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/tag/BooleanTag.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/BooleanTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/tag/IntTag.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/IntTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/tag/ShortTag.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/ShortTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/tag/StringTag.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/StringTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/main/java/io/opentracing/tag/Tags.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/Tags.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/test/java/io/opentracing/AssertionTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/AssertionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -11,7 +11,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.opentracing;
 
 import org.junit.Test;

--- a/opentracing-api/src/test/java/io/opentracing/propagation/BuiltinFormatTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/propagation/BuiltinFormatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/test/java/io/opentracing/tag/AbstractTagTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/tag/AbstractTagTest.java
@@ -13,12 +13,13 @@
  */
 package io.opentracing.tag;
 
-import io.opentracing.ActiveSpan;
-import io.opentracing.Span;
-import org.junit.Test;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import io.opentracing.ActiveSpan;
+import io.opentracing.Span;
 
 /**
  * @author Pavol Loffay

--- a/opentracing-api/src/test/java/io/opentracing/tag/AbstractTagTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/tag/AbstractTagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -11,16 +11,14 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.opentracing.tag;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-import org.junit.Test;
 
 import io.opentracing.ActiveSpan;
 import io.opentracing.Span;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Pavol Loffay

--- a/opentracing-api/src/test/java/io/opentracing/tag/BooleanTagTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/tag/BooleanTagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/test/java/io/opentracing/tag/IntTagTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/tag/IntTagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/test/java/io/opentracing/tag/ShortTagTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/tag/ShortTagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-api/src/test/java/io/opentracing/tag/StringTagTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/tag/StringTagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -16,11 +16,7 @@ package io.opentracing.mock;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
@@ -16,7 +16,11 @@ package io.opentracing.mock;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
@@ -16,11 +16,7 @@ package io.opentracing.mock;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -13,11 +13,23 @@
  */
 package io.opentracing.mock;
 
-import io.opentracing.*;
+import io.opentracing.ActiveSpan;
+import io.opentracing.ActiveSpanSource;
+import io.opentracing.BaseSpan;
+import io.opentracing.NoopActiveSpanSource;
+import io.opentracing.References;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * MockTracer makes it easy to test the semantics of OpenTracing instrumentation.

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -13,11 +13,23 @@
  */
 package io.opentracing.mock;
 
-import io.opentracing.*;
+import io.opentracing.ActiveSpan;
+import io.opentracing.ActiveSpanSource;
+import io.opentracing.BaseSpan;
+import io.opentracing.NoopActiveSpanSource;
+import io.opentracing.References;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * MockTracer makes it easy to test the semantics of OpenTracing instrumentation.
@@ -195,6 +207,7 @@ public class MockTracer implements Tracer {
         SpanBuilder(String operationName) {
             this.operationName = operationName;
         }
+
         @Override
         public SpanBuilder asChildOf(SpanContext parent) {
             return addReference(References.CHILD_OF, parent);
@@ -261,7 +274,7 @@ public class MockTracer implements Tracer {
                 this.startMicros = MockSpan.nowMicros();
             }
             if (firstParent == null && !ignoringActiveSpan) {
-                firstParent = (MockSpan.MockContext)activeSpanContext();
+                firstParent = (MockSpan.MockContext) activeSpanContext();
             }
             return new MockSpan(MockTracer.this, operationName, startMicros, initialTags, firstParent);
         }

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -13,23 +13,11 @@
  */
 package io.opentracing.mock;
 
-import io.opentracing.ActiveSpan;
-import io.opentracing.ActiveSpanSource;
-import io.opentracing.BaseSpan;
-import io.opentracing.NoopActiveSpanSource;
-import io.opentracing.References;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.Tracer;
+import io.opentracing.*;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * MockTracer makes it easy to test the semantics of OpenTracing instrumentation.

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -13,23 +13,11 @@
  */
 package io.opentracing.mock;
 
-import io.opentracing.ActiveSpan;
-import io.opentracing.ActiveSpanSource;
-import io.opentracing.BaseSpan;
-import io.opentracing.NoopActiveSpanSource;
-import io.opentracing.References;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.Tracer;
+import io.opentracing.*;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * MockTracer makes it easy to test the semantics of OpenTracing instrumentation.

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockSpanTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockSpanTest.java
@@ -13,9 +13,10 @@
  */
 package io.opentracing.mock;
 
-import io.opentracing.Span;
 import org.junit.Assert;
 import org.junit.Test;
+
+import io.opentracing.Span;
 
 /**
  * @author Pavol Loffay

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockSpanTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockSpanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -13,10 +13,9 @@
  */
 package io.opentracing.mock;
 
+import io.opentracing.Span;
 import org.junit.Assert;
 import org.junit.Test;
-
-import io.opentracing.Span;
 
 /**
  * @author Pavol Loffay

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-noop/src/main/java/io/opentracing/NoopActiveSpanSource.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopActiveSpanSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpanBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-noop/src/main/java/io/opentracing/NoopSpanContext.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopSpanContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-noop/src/main/java/io/opentracing/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopTracer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-noop/src/main/java/io/opentracing/NoopTracerFactory.java
+++ b/opentracing-noop/src/main/java/io/opentracing/NoopTracerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
@@ -13,7 +13,12 @@
  */
 package io.opentracing.util;
 
-import io.opentracing.*;
+import io.opentracing.ActiveSpan;
+import io.opentracing.NoopTracer;
+import io.opentracing.NoopTracerFactory;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 
 import java.util.logging.Level;

--- a/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -13,12 +13,7 @@
  */
 package io.opentracing.util;
 
-import io.opentracing.ActiveSpan;
-import io.opentracing.NoopTracer;
-import io.opentracing.NoopTracerFactory;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.Tracer;
+import io.opentracing.*;
 import io.opentracing.propagation.Format;
 
 import java.util.logging.Level;

--- a/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
@@ -13,12 +13,7 @@
  */
 package io.opentracing.util;
 
-import io.opentracing.ActiveSpan;
-import io.opentracing.NoopTracer;
-import io.opentracing.NoopTracerFactory;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.Tracer;
+import io.opentracing.*;
 import io.opentracing.propagation.Format;
 
 import java.util.logging.Level;

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpan.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -13,11 +13,7 @@
  */
 package io.opentracing.util;
 
-import io.opentracing.ActiveSpan;
-import io.opentracing.ActiveSpanSource;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.Tracer;
+import io.opentracing.*;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpan.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpan.java
@@ -13,18 +13,22 @@
  */
 package io.opentracing.util;
 
-import io.opentracing.*;
+import io.opentracing.ActiveSpan;
+import io.opentracing.ActiveSpanSource;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
- /**
-  * {@link ThreadLocalActiveSpan} is a simple {@link ActiveSpan} implementation that relies on Java's
-  * thread-local storage primitive.
-  *
-  * @see ActiveSpanSource
-  * @see Tracer#activeSpan()
-  */
+/**
+ * {@link ThreadLocalActiveSpan} is a simple {@link ActiveSpan} implementation that relies on Java's
+ * thread-local storage primitive.
+ *
+ * @see ActiveSpanSource
+ * @see Tracer#activeSpan()
+ */
 public class ThreadLocalActiveSpan implements ActiveSpan {
     private final ThreadLocalActiveSpanSource source;
     private final Span wrapped;
@@ -149,4 +153,4 @@ public class ThreadLocalActiveSpan implements ActiveSpan {
         }
     }
 
- }
+}

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpan.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpan.java
@@ -13,22 +13,18 @@
  */
 package io.opentracing.util;
 
-import io.opentracing.ActiveSpan;
-import io.opentracing.ActiveSpanSource;
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import io.opentracing.Tracer;
+import io.opentracing.*;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/**
- * {@link ThreadLocalActiveSpan} is a simple {@link ActiveSpan} implementation that relies on Java's
- * thread-local storage primitive.
- *
- * @see ActiveSpanSource
- * @see Tracer#activeSpan()
- */
+ /**
+  * {@link ThreadLocalActiveSpan} is a simple {@link ActiveSpan} implementation that relies on Java's
+  * thread-local storage primitive.
+  *
+  * @see ActiveSpanSource
+  * @see Tracer#activeSpan()
+  */
 public class ThreadLocalActiveSpan implements ActiveSpan {
     private final ThreadLocalActiveSpanSource source;
     private final Span wrapped;
@@ -153,4 +149,4 @@ public class ThreadLocalActiveSpan implements ActiveSpan {
         }
     }
 
-}
+ }

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpanSource.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpanSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-util/src/test/java/io/opentracing/util/GlobalTracerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/GlobalTracerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanSourceTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
@@ -18,14 +18,8 @@ import io.opentracing.Span;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class ThreadLocalActiveSpanTest {
     private ThreadLocalActiveSpanSource source;

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
@@ -18,8 +18,14 @@ import io.opentracing.Span;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 
 public class ThreadLocalActiveSpanTest {
     private ThreadLocalActiveSpanSource source;

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
@@ -18,14 +18,11 @@ import io.opentracing.Span;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
 
 public class ThreadLocalActiveSpanTest {
     private ThreadLocalActiveSpanSource source;

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016-2017 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -19,10 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class ThreadLocalActiveSpanTest {
     private ThreadLocalActiveSpanSource source;

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <maven-source-plugin.version>3.0.0</maven-source-plugin.version>
         <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
-        <license-maven-plugin.version>2.11</license-maven-plugin.version>
+        <license-maven-plugin.version>3.0</license-maven-plugin.version>
         <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <centralsync-maven-plugin.version>0.1.0</centralsync-maven-plugin.version>
@@ -252,6 +252,9 @@
                 <version>${license-maven-plugin.version}</version>
                 <configuration>
                     <header>${main.basedir}/src/etc/header.txt</header>
+                    <mapping>
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
                     <excludes>
                         <exclude>.travis.yml</exclude>
                         <exclude>.gitignore</exclude>


### PR DESCRIPTION
This avoids automatically adding `<P>` between the paragraphs every time an IDE (like IntelliJ) auto-formats the code.