### PR TITLE
Qualify use of GlobalTracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ Packages are deployed to Maven Central under the `io.opentracing` group.
 
 ### Initialization
 
-Initialization is OpenTracing-implementation-specific. Generally speaking, the pattern is to initialize a `Tracer` once for the entire process and to use that `Tracer` for the remainder of the process lifetime. The [GlobalTracer](https://github.com/opentracing/opentracing-java/blob/master/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java) provides a helper for singleton access to the `Tracer`.
+Initialization is OpenTracing-implementation-specific. Generally speaking, the pattern is to initialize a `Tracer` once for the entire process and to use that `Tracer` for the remainder of the process lifetime. It is a best practice to _set_ the [GlobalTracer](https://github.com/opentracing/opentracing-java/blob/master/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java), even if also making use of cleaner, more modern dependency injection. (See the next section below for rationale)
+
+### Accessing the `Tracer`
+
+Where possible, use dependency injection (of which there are many) to access the `Tracer` instance. For vanilla application code, this is often reasonable and cleaner for all of the usual DI reasons.
+
+That said, instrumentation for packages that are themselves statically configured (e.g., JDBC drivers) may be unable to make use of said DI mechanisms for `Tracer` access, and as such they should fall back on [GlobalTracer](https://github.com/opentracing/opentracing-java/blob/master/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java). By and large, OpenTracing instrumentation should always allow the programmer to specify a `Tracer` instance to use for instrumentation, though the [GlobalTracer](https://github.com/opentracing/opentracing-java/blob/master/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java) is a reasonable fallback or default value.
 
 ### `ActiveSpan`s, `Continuation`s, and within-process propagation
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Initialization is OpenTracing-implementation-specific. Generally speaking, the p
 
 ### Accessing the `Tracer`
 
-Where possible, use dependency injection (of which there are many) to access the `Tracer` instance. For vanilla application code, this is often reasonable and cleaner for all of the usual DI reasons.
+Where possible, use some form of dependency injection (of which there are many) to access the `Tracer` instance. For vanilla application code, this is often reasonable and cleaner for all of the usual DI reasons.
 
 That said, instrumentation for packages that are themselves statically configured (e.g., JDBC drivers) may be unable to make use of said DI mechanisms for `Tracer` access, and as such they should fall back on [GlobalTracer](https://github.com/opentracing/opentracing-java/blob/master/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java). By and large, OpenTracing instrumentation should always allow the programmer to specify a `Tracer` instance to use for instrumentation, though the [GlobalTracer](https://github.com/opentracing/opentracing-java/blob/master/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java) is a reasonable fallback or default value.
 

--- a/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
@@ -25,13 +25,28 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Global tracer that forwards all methods to another tracer
- * that can be configured by calling {@link #register(Tracer)}.
+ * Global tracer that forwards all methods to another tracer that can be
+ * configured by calling {@link #register(Tracer)}.
+ *
  * <p>
  * The {@linkplain #register(Tracer) register} method should only be called once
  * during the application initialization phase.<br>
  * If the {@linkplain #register(Tracer) register} method is never called,
  * the default {@link NoopTracer} is used.
+ *
+ * <p>
+ * Where possible, use some form of dependency injection (of which there are
+ * many) to access the `Tracer` instance. For vanilla application code, this is
+ * often reasonable and cleaner for all of the usual DI reasons.
+ *
+ * <p>
+ * That said, instrumentation for packages that are themselves statically
+ * configured (e.g., JDBC drivers) may be unable to make use of said DI
+ * mechanisms for {@link Tracer} access, and as such they should fall back on
+ * {@link GlobalTracer}. By and large, OpenTracing instrumentation should
+ * always allow the programmer to specify a {@link Tracer} instance to use for
+ * instrumentation, though the {@link GlobalTracer} is a reasonable fallback or
+ * default value.
  */
 public final class GlobalTracer implements Tracer {
     private static final Logger LOGGER = Logger.getLogger(GlobalTracer.class.getName());


### PR DESCRIPTION
Inasmuch as a singleton mechanism is needed in some places, it ought to be part of OT-Java's core API. That said, it's not a recommended best practice when more modern options are available.

Closes #140.