### PR TITLE
Fixes release pattern

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -72,7 +72,7 @@ check_release_tag() {
 }
 
 is_release_commit() {
-  project_version=$(./mvnw help:evaluate -N -Dexpression=project.version|grep -v '\[')
+  project_version=$(./mvnw help:evaluate -N -Dexpression=project.version|sed -n '/^[0-9]/p')
   if [[ "$project_version" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(\.RC[[:digit:]]+)?$ ]]; then
     echo "Build started by release commit $project_version. Will synchronize to maven central."
     return 0


### PR DESCRIPTION
A recent change to the ./mvnw script changed output slightly and broke
the logic which detected versions. This fixes it.

This should be applied to anything that uses this script