### PR TITLE
Idiomatic Java timestamps (#180)

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/BaseSpan.java
+++ b/opentracing-api/src/main/java/io/opentracing/BaseSpan.java
@@ -14,6 +14,7 @@
 package io.opentracing;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * {@link BaseSpan} represents the OpenTracing specification's span contract with the exception of methods to finish
@@ -75,14 +76,15 @@ public interface BaseSpan<S extends BaseSpan> {
      * <p><strong>CAUTIONARY NOTE:</strong> not all Tracer implementations support key:value log fields end-to-end.
      * Caveat emptor.
      *
-     * @param timestampMicroseconds The explicit timestamp for the log record. Must be greater than or equal to the
-     *                              Span's start timestamp.
+     * @param timestamp The explicit timestamp for the log record. Must be greater than or equal to the
+     *                  Span's start timestamp.
+     * @param timestampUnit The time unit which {@code timestamp} is provided in
      * @param fields key:value log fields. Tracer implementations should support String, numeric, and boolean values;
      *               some may also support arbitrary Objects.
      * @return the Span, for chaining
-     * @see Span#log(long, String)
+     * @see Span#log(long, TimeUnit, String)
      */
-    S log(long timestampMicroseconds, Map<String, ?> fields);
+    S log(long timestamp, TimeUnit timestampUnit, Map<String, ?> fields);
 
     /**
      * Record an event at the current walltime timestamp.
@@ -107,12 +109,13 @@ public interface BaseSpan<S extends BaseSpan> {
      span.log(timestampMicroseconds, Collections.singletonMap("event", event));
      </code></pre>
      *
-     * @param timestampMicroseconds The explicit timestamp for the log record. Must be greater than or equal to the
-     *                              Span's start timestamp.
+     * @param timestamp The explicit timestamp for the log record. Must be greater than or equal to the
+     *                  Span's start timestamp.
+     * @param timestampUnit The time unit which {@code timestamp} is provided in
      * @param event the event value; often a stable identifier for a moment in the Span lifecycle
      * @return the Span, for chaining
      */
-    S log(long timestampMicroseconds, String event);
+    S log(long timestamp, TimeUnit timestampUnit, String event);
 
     /**
      * Sets a baggage item in the Span (and its SpanContext) as a key/value pair.

--- a/opentracing-api/src/main/java/io/opentracing/BaseSpan.java
+++ b/opentracing-api/src/main/java/io/opentracing/BaseSpan.java
@@ -76,6 +76,23 @@ public interface BaseSpan<S extends BaseSpan> {
      * <p><strong>CAUTIONARY NOTE:</strong> not all Tracer implementations support key:value log fields end-to-end.
      * Caveat emptor.
      *
+     * @param timestampMicroseconds The explicit timestamp for the log record. Must be greater than or equal to the
+     *                              Span's start timestamp.
+     * @param fields key:value log fields. Tracer implementations should support String, numeric, and boolean values;
+     *               some may also support arbitrary Objects.
+     * @return the Span, for chaining
+     * @see Span#log(long, String)
+     * @deprecated Use the {@link #log(long, TimeUnit, Map)} instead
+     */
+    @Deprecated
+    S log(long timestampMicroseconds, Map<String, ?> fields);
+
+    /**
+     * Like log(Map&lt;String, Object&gt;), but with an explicit timestamp.
+     *
+     * <p><strong>CAUTIONARY NOTE:</strong> not all Tracer implementations support key:value log fields end-to-end.
+     * Caveat emptor.
+     *
      * @param timestamp The explicit timestamp for the log record. Must be greater than or equal to the
      *                  Span's start timestamp.
      * @param timestampUnit The time unit which {@code timestamp} is provided in
@@ -99,6 +116,24 @@ public interface BaseSpan<S extends BaseSpan> {
      * @return the Span, for chaining
      */
     S log(String event);
+
+    /**
+     * Record an event at a specific timestamp.
+     *
+     * Shorthand for
+     *
+     * <pre><code>
+     span.log(timestampMicroseconds, Collections.singletonMap("event", event));
+     </code></pre>
+     *
+     * @param timestampMicroseconds The explicit timestamp for the log record. Must be greater than or equal to the
+     *                              Span's start timestamp.
+     * @param event the event value; often a stable identifier for a moment in the Span lifecycle
+     * @return the Span, for chaining
+     * @deprecated Use the {@link #log(long, TimeUnit, String)} instead
+     */
+    @Deprecated
+    S log(long timestampMicroseconds, String event);
 
     /**
      * Record an event at a specific timestamp.

--- a/opentracing-api/src/main/java/io/opentracing/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/Span.java
@@ -13,6 +13,8 @@
  */
 package io.opentracing;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Represents an in-flight Span that's <strong>manually propagated</strong> within the given process. Most of
  * the API lives in {@link BaseSpan}.
@@ -40,9 +42,10 @@ public interface Span extends BaseSpan<Span> {
      * <p>With the exception of calls to Span.context(), this should be the last call made to the span instance, and to
      * do otherwise leads to undefined behavior.
      *
-     * @param finishMicros an explicit finish time, in microseconds since the epoch
+     * @param finishTimestamp an explicit finish time stamp, since the epoch
+     * @param finishUnit unit that {@code finishTimestamp} is provided in
      *
      * @see Span#context()
      */
-    void finish(long finishMicros);
+    void finish(long finishTimestamp, TimeUnit finishUnit);
 }

--- a/opentracing-api/src/main/java/io/opentracing/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/Span.java
@@ -42,6 +42,20 @@ public interface Span extends BaseSpan<Span> {
      * <p>With the exception of calls to Span.context(), this should be the last call made to the span instance, and to
      * do otherwise leads to undefined behavior.
      *
+     * @param finishMicros an explicit finish time, in microseconds since the epoch
+     *
+     * @see Span#context()
+     * @deprecated Use {@link #finish(long, TimeUnit)} instead
+     */
+    @Deprecated
+    void finish(long finishMicros);
+
+    /**
+     * Sets an explicit end timestamp and records the span.
+     *
+     * <p>With the exception of calls to Span.context(), this should be the last call made to the span instance, and to
+     * do otherwise leads to undefined behavior.
+     *
      * @param finishTimestamp an explicit finish time stamp, since the epoch
      * @param finishUnit unit that {@code finishTimestamp} is provided in
      *

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -15,6 +15,8 @@ package io.opentracing;
 
 import io.opentracing.propagation.Format;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Tracer is a simple, thin interface for Span creation and propagation across arbitrary transports.
  */
@@ -151,8 +153,8 @@ public interface Tracer extends ActiveSpanSource {
         /** Same as {@link Span#setTag(String, Number)}, but for the span being built. */
         SpanBuilder withTag(String key, Number value);
 
-        /** Specify a timestamp of when the Span was started, represented in microseconds since epoch. */
-        SpanBuilder withStartTimestamp(long microseconds);
+        /** Specify a timestamp of when the Span was started, since the epoch. */
+        SpanBuilder withStartTimestamp(long startTimestamp, TimeUnit startUnit);
 
         /**
          * Returns a newly started and activated {@link ActiveSpan}.

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -153,6 +153,14 @@ public interface Tracer extends ActiveSpanSource {
         /** Same as {@link Span#setTag(String, Number)}, but for the span being built. */
         SpanBuilder withTag(String key, Number value);
 
+        /**
+         * Specify a timestamp of when the Span was started, represented in microseconds since epoch.
+         *
+         * @deprecated Use {@link #withStartTimestamp(long, TimeUnit)} instead
+         */
+        @Deprecated
+        SpanBuilder withStartTimestamp(long microseconds);
+
         /** Specify a timestamp of when the Span was started, since the epoch. */
         SpanBuilder withStartTimestamp(long startTimestamp, TimeUnit startUnit);
 

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
@@ -13,6 +13,9 @@
  */
 package io.opentracing.mock;
 
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -20,9 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
 
 /**
  * MockSpans are created via MockTracer.buildSpan(...), but they are also returned via calls to
@@ -112,6 +112,12 @@ public final class MockSpan implements Span {
     }
 
     @Override
+    @Deprecated
+    public void finish(long finishMicros) {
+        finish(finishMicros, TimeUnit.MICROSECONDS);
+    }
+
+    @Override
     public synchronized void finish(long finishTimestamp, TimeUnit finishUnit) {
         finishedCheck("Finishing already finished span");
         this.finishTimestamp = finishTimestamp;
@@ -147,6 +153,12 @@ public final class MockSpan implements Span {
     }
 
     @Override
+    @Deprecated
+    public Span log(long timestampMicroseconds, Map<String, ?> fields) {
+        return log(timestampMicroseconds, TimeUnit.MICROSECONDS, fields);
+    }
+
+    @Override
     public final synchronized MockSpan log(long timestamp, TimeUnit timestampUnit, Map<String, ?> fields) {
         finishedCheck("Adding logs %s at %d %s to already finished span", fields, timestamp, timestampUnit);
         this.logEntries.add(new LogEntry(timestamp, timestampUnit, fields));
@@ -156,6 +168,12 @@ public final class MockSpan implements Span {
     @Override
     public MockSpan log(String event) {
         return this.log(nowMillis(), TimeUnit.MILLISECONDS, event);
+    }
+
+    @Override
+    @Deprecated
+    public Span log(long timestampMicroseconds, String event) {
+        return log(timestampMicroseconds, TimeUnit.MICROSECONDS, event);
     }
 
     @Override

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -16,11 +16,11 @@ package io.opentracing.mock;
 import io.opentracing.ActiveSpan;
 import io.opentracing.ActiveSpanSource;
 import io.opentracing.BaseSpan;
-import io.opentracing.noop.NoopActiveSpanSource;
 import io.opentracing.References;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+import io.opentracing.noop.NoopActiveSpanSource;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.util.ThreadLocalActiveSpanSource;
@@ -259,6 +259,12 @@ public class MockTracer implements Tracer {
         }
 
         @Override
+        @Deprecated
+        public Tracer.SpanBuilder withStartTimestamp(long microseconds) {
+            return withStartTimestamp(microseconds, TimeUnit.MICROSECONDS);
+        }
+
+        @Override
         public SpanBuilder withStartTimestamp(long startTimestamp, TimeUnit startUnit) {
             this.startTimestamp = startTimestamp;
             this.startUnit = startUnit;
@@ -266,6 +272,7 @@ public class MockTracer implements Tracer {
         }
 
         @Override
+        @Deprecated
         public MockSpan start() {
             return startManual();
         }

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * MockTracer makes it easy to test the semantics of OpenTracing instrumentation.
@@ -204,7 +205,8 @@ public class MockTracer implements Tracer {
 
     public final class SpanBuilder implements Tracer.SpanBuilder {
         private final String operationName;
-        private long startMicros;
+        private long startTimestamp;
+        private TimeUnit startUnit;
         private MockSpan.MockContext firstParent;
         private boolean ignoringActiveSpan;
         private Map<String, Object> initialTags = new HashMap<>();
@@ -257,8 +259,9 @@ public class MockTracer implements Tracer {
         }
 
         @Override
-        public SpanBuilder withStartTimestamp(long microseconds) {
-            this.startMicros = microseconds;
+        public SpanBuilder withStartTimestamp(long startTimestamp, TimeUnit startUnit) {
+            this.startTimestamp = startTimestamp;
+            this.startUnit = startUnit;
             return this;
         }
 
@@ -275,13 +278,14 @@ public class MockTracer implements Tracer {
 
         @Override
         public MockSpan startManual() {
-            if (this.startMicros == 0) {
-                this.startMicros = MockSpan.nowMicros();
+            if (this.startTimestamp == 0) {
+                this.startTimestamp = MockSpan.nowMillis();
+                this.startUnit = TimeUnit.MILLISECONDS;
             }
             if (firstParent == null && !ignoringActiveSpan) {
                 firstParent = (MockSpan.MockContext) activeSpanContext();
             }
-            return new MockSpan(MockTracer.this, operationName, startMicros, initialTags, firstParent);
+            return new MockSpan(MockTracer.this, operationName, startTimestamp, startUnit, initialTags, firstParent);
         }
     }
 }

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -13,22 +13,22 @@
  */
 package io.opentracing.mock;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMapExtractAdapter;
 import io.opentracing.propagation.TextMapInjectAdapter;
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class MockTracerTest {
     @Test
@@ -124,6 +124,23 @@ public class MockTracerTest {
     }
 
     @Test
+    @SuppressWarnings("deprecated")
+    public void testStartExplicitTimestampInMicroseconds() throws InterruptedException {
+        MockTracer tracer = new MockTracer();
+        long startMicros = 2000;
+        {
+            tracer.buildSpan("foo")
+                    .withStartTimestamp(startMicros)
+                    .startManual()
+                    .finish();
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        Assert.assertEquals(1, finishedSpans.size());
+        Assert.assertEquals(startMicros, finishedSpans.get(0).startTimestamp(TimeUnit.MICROSECONDS));
+    }
+
+    @Test
     public void testStartExplicitTimestamp() throws InterruptedException {
         MockTracer tracer = new MockTracer();
         long startMicros = 2000;
@@ -131,7 +148,7 @@ public class MockTracerTest {
         {
             tracer.buildSpan("foo")
                     .withStartTimestamp(startMicros, startUnit)
-                    .start()
+                    .startManual()
                     .finish();
         }
         List<MockSpan> finishedSpans = tracer.finishedSpans();

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopActiveSpanSource.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopActiveSpanSource.java
@@ -82,12 +82,24 @@ class NoopActiveSpanSourceImpl implements NoopActiveSpanSource {
         }
 
         @Override
+        @Deprecated
+        public ActiveSpan log(long timestampMicroseconds, Map<String, ?> fields) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
         public NoopActiveSpan log(long timestamp, TimeUnit timestampUnit, Map<String, ?> fields) {
             return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
         }
 
         @Override
         public NoopActiveSpan log(String event) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        @Deprecated
+        public ActiveSpan log(long timestampMicroseconds, String event) {
             return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
         }
 

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopActiveSpanSource.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopActiveSpanSource.java
@@ -19,6 +19,7 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public interface NoopActiveSpanSource extends ActiveSpanSource {
     NoopActiveSpanSource INSTANCE = new NoopActiveSpanSourceImpl();
@@ -81,7 +82,7 @@ class NoopActiveSpanSourceImpl implements NoopActiveSpanSource {
         }
 
         @Override
-        public NoopActiveSpan log(long timestampMicroseconds, Map<String, ?> fields) {
+        public NoopActiveSpan log(long timestamp, TimeUnit timestampUnit, Map<String, ?> fields) {
             return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
         }
 
@@ -91,7 +92,7 @@ class NoopActiveSpanSourceImpl implements NoopActiveSpanSource {
         }
 
         @Override
-        public NoopActiveSpan log(long timestampMicroseconds, String event) {
+        public NoopActiveSpan log(long timestamp, TimeUnit timestampUnit, String event) {
             return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
         }
 

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
@@ -17,6 +17,7 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public interface NoopSpan extends Span {
     static final NoopSpan INSTANCE = new NoopSpanImpl();
@@ -31,7 +32,7 @@ final class NoopSpanImpl implements NoopSpan {
     public void finish() {}
 
     @Override
-    public void finish(long finishMicros) {}
+    public void finish(long finishTimestamp, TimeUnit finishUnit) {}
 
     @Override
     public NoopSpan setTag(String key, String value) { return this; }
@@ -46,13 +47,13 @@ final class NoopSpanImpl implements NoopSpan {
     public NoopSpan log(Map<String, ?> fields) { return this; }
 
     @Override
-    public NoopSpan log(long timestampMicroseconds, Map<String, ?> fields) { return this; }
+    public NoopSpan log(long timestamp, TimeUnit timestampUnit, Map<String, ?> fields) { return this; }
 
     @Override
     public NoopSpan log(String event) { return this; }
 
     @Override
-    public NoopSpan log(long timestampMicroseconds, String event) { return this; }
+    public NoopSpan log(long timestamp, TimeUnit timestampUnit, String event) { return this; }
 
     @Override
     public NoopSpan setBaggageItem(String key, String value) { return this; }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
@@ -32,6 +32,10 @@ final class NoopSpanImpl implements NoopSpan {
     public void finish() {}
 
     @Override
+    @Deprecated
+    public void finish(long finishMicros) {}
+
+    @Override
     public void finish(long finishTimestamp, TimeUnit finishUnit) {}
 
     @Override
@@ -47,10 +51,22 @@ final class NoopSpanImpl implements NoopSpan {
     public NoopSpan log(Map<String, ?> fields) { return this; }
 
     @Override
+    @Deprecated
+    public Span log(long timestampMicroseconds, Map<String, ?> fields) {
+        return this;
+    }
+
+    @Override
     public NoopSpan log(long timestamp, TimeUnit timestampUnit, Map<String, ?> fields) { return this; }
 
     @Override
     public NoopSpan log(String event) { return this; }
+
+    @Override
+    @Deprecated
+    public Span log(long timestampMicroseconds, String event) {
+        return this;
+    }
 
     @Override
     public NoopSpan log(long timestamp, TimeUnit timestampUnit, String event) { return this; }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
@@ -21,6 +21,7 @@ import io.opentracing.Tracer;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public interface NoopSpanBuilder extends Tracer.SpanBuilder, NoopSpanContext {
     static final NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
@@ -62,7 +63,7 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
     }
 
     @Override
-    public Tracer.SpanBuilder withStartTimestamp(long microseconds) {
+    public Tracer.SpanBuilder withStartTimestamp(long startTimestamp, TimeUnit startUnit) {
         return this;
     }
 

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
@@ -63,11 +63,18 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
     }
 
     @Override
+    @Deprecated
+    public Tracer.SpanBuilder withStartTimestamp(long microseconds) {
+        return this;
+    }
+
+    @Override
     public Tracer.SpanBuilder withStartTimestamp(long startTimestamp, TimeUnit startUnit) {
         return this;
     }
 
     @Override
+    @Deprecated
     public Span start() {
         return startManual();
     }

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpan.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpan.java
@@ -92,6 +92,12 @@ public class ThreadLocalActiveSpan implements ActiveSpan {
     }
 
     @Override
+    @Deprecated
+    public ActiveSpan log(long timestampMicroseconds, Map<String, ?> fields) {
+        return log(timestampMicroseconds, TimeUnit.MICROSECONDS, fields);
+    }
+
+    @Override
     public ThreadLocalActiveSpan log(long timestamp, TimeUnit timestampUnit, Map<String, ?> fields) {
         wrapped.log(timestamp, timestampUnit, fields);
         return this;
@@ -101,6 +107,12 @@ public class ThreadLocalActiveSpan implements ActiveSpan {
     public ThreadLocalActiveSpan log(String event) {
         wrapped.log(event);
         return this;
+    }
+
+    @Override
+    @Deprecated
+    public ActiveSpan log(long timestampMicroseconds, String event) {
+        return log(timestampMicroseconds, TimeUnit.MICROSECONDS, event);
     }
 
     @Override

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpan.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpan.java
@@ -13,14 +13,15 @@
  */
 package io.opentracing.util;
 
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import io.opentracing.ActiveSpan;
 import io.opentracing.ActiveSpanSource;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * {@link ThreadLocalActiveSpan} is a simple {@link ActiveSpan} implementation that relies on Java's
@@ -91,8 +92,8 @@ public class ThreadLocalActiveSpan implements ActiveSpan {
     }
 
     @Override
-    public ThreadLocalActiveSpan log(long timestampMicroseconds, Map<String, ?> fields) {
-        wrapped.log(timestampMicroseconds, fields);
+    public ThreadLocalActiveSpan log(long timestamp, TimeUnit timestampUnit, Map<String, ?> fields) {
+        wrapped.log(timestamp, timestampUnit, fields);
         return this;
     }
 
@@ -103,8 +104,8 @@ public class ThreadLocalActiveSpan implements ActiveSpan {
     }
 
     @Override
-    public ThreadLocalActiveSpan log(long timestampMicroseconds, String event) {
-        wrapped.log(timestampMicroseconds, event);
+    public ThreadLocalActiveSpan log(long timestamp, TimeUnit timestampUnit, String event) {
+        wrapped.log(timestamp, timestampUnit, event);
         return this;
     }
 

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
@@ -13,18 +13,17 @@
  */
 package io.opentracing.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import io.opentracing.ActiveSpan;
 import io.opentracing.Span;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class ThreadLocalActiveSpanTest {
     private ThreadLocalActiveSpanSource source;
@@ -110,5 +109,53 @@ public class ThreadLocalActiveSpanTest {
         activeSpan.deactivate();
 
         verify(span, times(0)).finish();
+    }
+
+    @Test
+    @SuppressWarnings("deprecated")
+    public void testLogEventWithTimestampInMicroseconds() {
+        Span span = mock(Span.class);
+
+        long now = System.currentTimeMillis() * 1000L;
+        ActiveSpan activeSpan = source.makeActive(span);
+        activeSpan.log(now, "event");
+
+        verify(span).log(now, TimeUnit.MICROSECONDS, "event");
+    }
+
+    @Test
+    public void testLogEventWithTimestamp() {
+        Span span = mock(Span.class);
+
+        long now = System.currentTimeMillis();
+        ActiveSpan activeSpan = source.makeActive(span);
+        activeSpan.log(now, TimeUnit.MILLISECONDS, "event");
+
+        verify(span).log(now, TimeUnit.MILLISECONDS, "event");
+    }
+
+    @Test
+    @SuppressWarnings("deprecated")
+    public void testLogFieldsWithTimestampInMicroseconds() {
+        Span span = mock(Span.class);
+        Map<String, ?> fields = Collections.emptyMap();
+
+        long now = System.currentTimeMillis() * 1000L;
+        ActiveSpan activeSpan = source.makeActive(span);
+        activeSpan.log(now, fields);
+
+        verify(span).log(now, TimeUnit.MICROSECONDS, fields);
+    }
+
+    @Test
+    public void testLogFieldsWithTimestamp() {
+        Span span = mock(Span.class);
+        Map<String, ?> fields = Collections.emptyMap();
+
+        long now = System.currentTimeMillis();
+        ActiveSpan activeSpan = source.makeActive(span);
+        activeSpan.log(now, TimeUnit.MILLISECONDS, fields);
+
+        verify(span).log(now, TimeUnit.MILLISECONDS, fields);
     }
 }


### PR DESCRIPTION
Proposal for changing the API surface area with respect to passing timestamps
into and out of the API, leveraging the (long, TimeUnit) tuple pattern than
was introduced in and encouraged after JDK 1.5.

Intended as a discussion point for Issue #180.