### PR TITLE
travis publish.sh allow releases from branches

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -35,12 +35,12 @@ is_pull_request() {
   fi
 }
 
-is_travis_branch_master() {
-  if [ "${TRAVIS_BRANCH}" = master ]; then
-    echo "[Publishing] Travis branch is master"
+is_travis_branch_master_or_release() {
+  if [[ "${TRAVIS_BRANCH}" == "master" || "${TRAVIS_BRANCH}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "[Publishing] Travis branch is ${TRAVIS_BRANCH}"
     return 0
   else
-    echo "[Not Publishing] Travis branch is not master"
+    echo "[Not Publishing] Travis branch is not master or 0.0.0"
     return 1
   fi
 }
@@ -60,12 +60,12 @@ check_travis_branch_equals_travis_tag() {
 
 check_release_tag() {
     tag="${TRAVIS_TAG}"
-    if [[ "$tag" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(\.RC[[:digit:]]+)?$ ]]; then
+    if [[ "$tag" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(\-RC[[:digit:]]+)?$ ]]; then
         echo "Build started by version tag $tag. During the release process tags like this"
         echo "are created by the 'release' Maven plugin. Nothing to do here."
         exit 0
-    elif [[ ! "$tag" =~ ^release-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(\.RC[[:digit:]]+)?$ ]]; then
-        echo "You must specify a tag of the format 'release-0.0.0' or 'release-0.0.0.RC0' to release this project."
+    elif [[ ! "$tag" =~ ^release-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(\-RC[[:digit:]]+)?$ ]]; then
+        echo "You must specify a tag of the format 'release-0.0.0' or 'release-0.0.0-RC0' to release this project."
         echo "The provided tag ${tag} doesn't match that. Aborting."
         exit 1
     fi
@@ -73,7 +73,7 @@ check_release_tag() {
 
 is_release_commit() {
   project_version=$(./mvnw help:evaluate -N -Dexpression=project.version|sed -n '/^[0-9]/p')
-  if [[ "$project_version" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(\.RC[[:digit:]]+)?$ ]]; then
+  if [[ "$project_version" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(\-RC[[:digit:]]+)?$ ]]; then
     echo "Build started by release commit $project_version. Will synchronize to maven central."
     return 0
   else
@@ -115,7 +115,7 @@ if is_pull_request; then
   true
 # If we are on master, we will deploy the latest snapshot or release version
 #   - If a release commit fails to deploy for a transient reason, delete the broken version from bintray and click rebuild
-elif is_travis_branch_master; then
+elif is_travis_branch_master_or_release; then
   ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy
 
   # If the deployment succeeded, sync it to Maven Central. Note: this needs to be done once per project, not module, hence -N


### PR DESCRIPTION
This should allow releasing from any `digit.digit.digit` branch. This uses `0.0.0-RC0` pattern for releases. 

To release switch to the `0.31.0` branch tag `release-0.31.0-RC1` and push to upstream.

cc @tedsuo 