### PR TITLE
Travis allow release from non master branches

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -86,9 +86,10 @@ release_version() {
 }
 
 safe_checkout_remote_branch() {
-  # We need to be on a branch for release:perform to be able to create commits, and we want that branch to be master.
-  # But we also want to make sure that we build and release exactly the tagged version, so we verify that the remote
-  # master is where our tag is.
+  # We need to be on a branch for release:perform to be able to create commits,
+  # and we want that branch to be master or 0.0.0. which has been checked before.
+  # But we also want to make sure that we build and release exactly the tagged version,
+  # so we verify that the remote branch is where our tag is.
   git checkout -B "${TRAVIS_BRANCH}"
   git fetch origin "${TRAVIS_BRANCH}":origin/"${TRAVIS_BRANCH}"
   commit_local="$(git show --pretty='format:%H' ${TRAVIS_BRANCH})"

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -85,16 +85,16 @@ release_version() {
     echo "${TRAVIS_TAG}" | sed 's/^release-//'
 }
 
-safe_checkout_master() {
+safe_checkout_remote_branch() {
   # We need to be on a branch for release:perform to be able to create commits, and we want that branch to be master.
   # But we also want to make sure that we build and release exactly the tagged version, so we verify that the remote
   # master is where our tag is.
-  git checkout -B master
-  git fetch origin master:origin/master
-  commit_local_master="$(git show --pretty='format:%H' master)"
-  commit_remote_master="$(git show --pretty='format:%H' origin/master)"
-  if [ "$commit_local_master" != "$commit_remote_master" ]; then
-    echo "Master on remote 'origin' has commits since the version under release, aborting"
+  git checkout -B "${TRAVIS_BRANCH}"
+  git fetch origin "${TRAVIS_BRANCH}":origin/"${TRAVIS_BRANCH}"
+  commit_local="$(git show --pretty='format:%H' ${TRAVIS_BRANCH})"
+  commit_remote="$(git show --pretty='format:%H' origin/${TRAVIS_BRANCH})"
+  if [ "$commit_local" != "$commit_remote" ]; then
+    echo "${TRAVIS_BRANCH} on remote 'origin' has commits since the version under release, aborting"
     exit 1
   fi
 }
@@ -125,7 +125,7 @@ elif is_travis_branch_master_or_release; then
 
 # If we are on a release tag, the following will update any version references and push a version tag for deployment.
 elif build_started_by_tag; then
-  safe_checkout_master
+  safe_checkout_remote_branch
   ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DreleaseVersion="$(release_version)" -Darguments="-DskipTests" release:prepare
 fi
 


### PR DESCRIPTION
Publis script compares remote branch with current checkout.
This passes travis_branch into git checkout command so
it will compare the same branches.

This is related to #191 , The build failed https://travis-ci.org/opentracing/opentracing-java/builds/279837722#L1176