### PR TITLE
Code cleanup

### DIFF
--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -258,6 +258,7 @@ public class MockTracer implements Tracer {
         }
 
         @Override
+        @Deprecated
         public MockSpan start() {
             return startManual();
         }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.Map;
 
 public interface NoopSpanBuilder extends Tracer.SpanBuilder, NoopSpanContext {
-    static final NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
+    NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
 }
 
 final class NoopSpanBuilderImpl implements NoopSpanBuilder {
@@ -76,6 +76,7 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
     }
 
     @Override
+    @Deprecated
     public Span start() {
         return startManual();
     }
@@ -87,7 +88,7 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
 
     @Override
     public Iterable<Map.Entry<String, String>> baggageItems() {
-        return Collections.EMPTY_MAP.entrySet();
+        return Collections.<String, String>emptyMap().entrySet();
     }
 
     @Override


### PR DESCRIPTION
- Propagate @deprecated annotation to implementations
- Remove redundant "static final" definition from interface
- Use Collections.emptyMap instead of Collections.EMPTY_MAP to preserve type