### PR TITLE
Idiomatic Java timestamps (#180)

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/Span.java
@@ -14,6 +14,7 @@
 package io.opentracing;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * {@link Span} represents the OpenTracing specification's Span contract.
@@ -79,8 +80,26 @@ public interface Span {
      *               some may also support arbitrary Objects.
      * @return the Span, for chaining
      * @see Span#log(long, String)
+     * @deprecated Use {@link #log(long, TimeUnit, Map)}
      */
+    @Deprecated
     Span log(long timestampMicroseconds, Map<String, ?> fields);
+
+    /**
+     * Like log(Map&lt;String, Object&gt;), but with an explicit timestamp.
+     *
+     * <p><strong>CAUTIONARY NOTE:</strong> not all Tracer implementations support key:value log fields end-to-end.
+     * Caveat emptor.
+     *
+     * @param timestamp The explicit timestamp for the log record in {@code timeUnit} units since the epoch. Must
+     *                  be greater than or equal to the Span's start timestamp.
+     * @param timeUnit  The unit ot time that {@code timestamp} is specified in
+     * @param fields key:value log fields. Tracer implementations should support String, numeric, and boolean values;
+     *               some may also support arbitrary Objects.
+     * @return the Span, for chaining
+     * @see Span#log(long, String)
+     */
+    Span log(long timestamp, TimeUnit timeUnit, Map<String, ?> fields);
 
     /**
      * Record an event at the current walltime timestamp.
@@ -109,8 +128,27 @@ public interface Span {
      *                              Span's start timestamp.
      * @param event the event value; often a stable identifier for a moment in the Span lifecycle
      * @return the Span, for chaining
+     * @deprecated Use {@link #log(long, TimeUnit, String)}
      */
+    @Deprecated
     Span log(long timestampMicroseconds, String event);
+
+    /**
+     * Record an event at a specific timestamp.
+     *
+     * Shorthand for
+     *
+     * <pre><code>
+     span.log(timestamp, timeUnit, Collections.singletonMap("event", event));
+     </code></pre>
+     *
+     * @param timestamp The explicit timestamp for the log record in {@code timeUnit} units since the epoch. Must
+     *                  be greater than or equal to the Span's start timestamp.
+     * @param timeUnit  The unit ot time that {@code timestamp} is specified in
+     * @param event the event value; often a stable identifier for a moment in the Span lifecycle
+     * @return the Span, for chaining
+     */
+    Span log(long timestamp, TimeUnit timeUnit, String event);
 
     /**
      * Sets a baggage item in the Span (and its SpanContext) as a key/value pair.
@@ -159,6 +197,21 @@ public interface Span {
      * @param finishMicros an explicit finish time, in microseconds since the epoch
      *
      * @see Span#context()
+     * @deprecated Use {@link #finish(long,TimeUnit)}
      */
+    @Deprecated
     void finish(long finishMicros);
+
+    /**
+     * Sets an explicit end timestamp and records the span.
+     *
+     * <p>With the exception of calls to Span.context(), this should be the last call made to the span instance, and to
+     * do otherwise leads to undefined behavior.
+     *
+     * @param finishTimestamp an explicit finish time, in {@code finishUnit}s since the epoch
+     * @param finishUnit time unit that {@code finishTimestamp} is specified in
+     *
+     * @see Span#context()
+     */
+    void finish(long finishTimestamp, TimeUnit finishUnit);
 }

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -15,6 +15,8 @@ package io.opentracing;
 
 import io.opentracing.propagation.Format;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Tracer is a simple, thin interface for Span creation and propagation across arbitrary transports.
  */
@@ -158,6 +160,9 @@ public interface Tracer {
 
         /** Specify a timestamp of when the Span was started, represented in microseconds since epoch. */
         SpanBuilder withStartTimestamp(long microseconds);
+
+        /** Specify a timestamp of when the Span was started, since the epoch. */
+        SpanBuilder withStartTimestamp(long startTimestamp, TimeUnit startUnit);
 
         /**
          * Returns a newly started and activated {@link Scope}.

--- a/opentracing-examples/src/test/java/io/opentracing/examples/TestUtils.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/TestUtils.java
@@ -73,14 +73,15 @@ public class TestUtils {
         Collections.sort(spans, new Comparator<MockSpan>() {
             @Override
             public int compare(MockSpan o1, MockSpan o2) {
-                return Long.compare(o1.startMicros(), o2.startMicros());
+                return Long.compare(o1.startTimestamp(TimeUnit.MICROSECONDS), o2.startTimestamp(TimeUnit.MICROSECONDS));
             }
         });
     }
 
     public static void assertSameTrace(List<MockSpan> spans) {
         for (int i = 0; i < spans.size() - 1; i++) {
-            assertEquals(true, spans.get(spans.size() - 1).finishMicros() >= spans.get(i).finishMicros());
+            assertEquals(true, spans.get(spans.size() - 1).finishTimestamp(TimeUnit.MICROSECONDS)
+                    >= spans.get(i).finishTimestamp(TimeUnit.MICROSECONDS));
             assertEquals(spans.get(spans.size() - 1).context().traceId(), spans.get(i).context().traceId());
             assertEquals(spans.get(spans.size() - 1).context().spanId(), spans.get(i).parentId());
         }

--- a/opentracing-examples/src/test/java/io/opentracing/examples/multiple_callbacks/MultipleCallbacksTest.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/multiple_callbacks/MultipleCallbacksTest.java
@@ -51,7 +51,8 @@ public class MultipleCallbacksTest {
 
         MockSpan parentSpan = spans.get(3);
         for (int i = 0; i < 3; i++) {
-            assertEquals(true, parentSpan.finishMicros() >= spans.get(i).finishMicros());
+            assertEquals(true, parentSpan.finishTimestamp(TimeUnit.MICROSECONDS)
+                    >= spans.get(i).finishTimestamp(TimeUnit.MICROSECONDS));
             assertEquals(parentSpan.context().traceId(), spans.get(i).context().traceId());
             assertEquals(parentSpan.context().spanId(), spans.get(i).parentId());
         }

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
@@ -13,15 +13,16 @@
  */
 package io.opentracing.mock;
 
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
 
 /**
  * MockSpans are created via MockTracer.buildSpan(...), but they are also returned via calls to
@@ -36,9 +37,11 @@ public final class MockSpan implements Span {
     private final MockTracer mockTracer;
     private MockContext context;
     private final long parentId; // 0 if there's no parent.
-    private final long startMicros;
+    private final long startTimestamp;
+    private final TimeUnit startUnit;
     private boolean finished;
-    private long finishMicros;
+    private long finishTimestamp;
+    private TimeUnit finishUnit;
     private final Map<String, Object> tags;
     private final List<LogEntry> logEntries = new ArrayList<>();
     private String operationName;
@@ -66,15 +69,38 @@ public final class MockSpan implements Span {
     public long parentId() {
         return parentId;
     }
+
+    /**
+     * @return the start time of the Span.
+     * @deprecated Use {@link #startTimestamp(TimeUnit)}
+     */
+    @Deprecated
     public long startMicros() {
-        return startMicros;
+        return startTimestamp(TimeUnit.MICROSECONDS);
     }
+
+    /**
+     * @return the start time of the Span in the specified units.
+     */
+    public long startTimestamp(TimeUnit unit) {
+        return unit.convert(startTimestamp, startUnit);
+    }
+
     /**
      * @return the finish time of the Span; only valid after a call to finish().
+     * @deprecated Use {@link #finishTimestamp(TimeUnit)}
      */
+    @Deprecated
     public long finishMicros() {
-        assert finishMicros > 0 : "must call finish() before finishMicros()";
-        return finishMicros;
+        return finishTimestamp(TimeUnit.MICROSECONDS);
+    }
+
+    /**
+     * @return the finish time of the Span in the specified units; only valid after a call to finish().
+     */
+    public long finishTimestamp(TimeUnit units) {
+        assert finishTimestamp > 0 : "must call finish() before finishTimestamp()";
+        return units.convert(finishTimestamp, finishUnit);
     }
 
     /**
@@ -104,13 +130,20 @@ public final class MockSpan implements Span {
 
     @Override
     public void finish() {
-        this.finish(nowMicros());
+        this.finish(nowMillis(), TimeUnit.MILLISECONDS);
     }
 
     @Override
+    @Deprecated
     public synchronized void finish(long finishMicros) {
+        finish(finishMicros, TimeUnit.MICROSECONDS);
+    }
+
+    @Override
+    public synchronized void finish(long finishTimestamp, TimeUnit finishUnit) {
         finishedCheck("Finishing already finished span");
-        this.finishMicros = finishMicros;
+        this.finishTimestamp = finishTimestamp;
+        this.finishUnit = finishUnit;
         this.mockTracer.appendFinishedSpan(this);
         this.finished = true;
     }
@@ -138,24 +171,36 @@ public final class MockSpan implements Span {
 
     @Override
     public final Span log(Map<String, ?> fields) {
-        return log(nowMicros(), fields);
+        return log(nowMillis(), TimeUnit.MILLISECONDS, fields);
     }
 
     @Override
+    @Deprecated
     public final synchronized MockSpan log(long timestampMicros, Map<String, ?> fields) {
-        finishedCheck("Adding logs %s at %d to already finished span", fields, timestampMicros);
-        this.logEntries.add(new LogEntry(timestampMicros, fields));
+        return log(timestampMicros, TimeUnit.MICROSECONDS, fields);
+    }
+
+    @Override
+    public final synchronized MockSpan log(long timestamp, TimeUnit timestampUnit, Map<String, ?> fields) {
+        finishedCheck("Adding logs %s at %d %s to already finished span", fields, timestamp, timestampUnit);
+        this.logEntries.add(new LogEntry(timestamp, timestampUnit, fields));
         return this;
     }
 
     @Override
     public MockSpan log(String event) {
-        return this.log(nowMicros(), event);
+        return this.log(nowMillis(), TimeUnit.MILLISECONDS, event);
     }
 
     @Override
+    @Deprecated
     public MockSpan log(long timestampMicroseconds, String event) {
-        return this.log(timestampMicroseconds, Collections.singletonMap("event", event));
+        return this.log(timestampMicroseconds, TimeUnit.MICROSECONDS, event);
+    }
+
+    @Override
+    public MockSpan log(long timestamp, TimeUnit timestampUnit, String event) {
+        return this.log(timestamp, timestampUnit, Collections.singletonMap("event", event));
     }
 
     @Override
@@ -215,16 +260,18 @@ public final class MockSpan implements Span {
     }
 
     public static final class LogEntry {
-        private final long timestampMicros;
+        private final long timestamp;
+        private final TimeUnit timestampUnit;
         private final Map<String, ?> fields;
 
-        public LogEntry(long timestampMicros, Map<String, ?> fields) {
-            this.timestampMicros = timestampMicros;
+        public LogEntry(long timestamp, TimeUnit timestampUnit, Map<String, ?> fields) {
+            this.timestamp = timestamp;
+            this.timestampUnit = timestampUnit;
             this.fields = fields;
         }
 
-        public long timestampMicros() {
-            return timestampMicros;
+        public long timestamp(TimeUnit unit) {
+            return unit.convert(timestamp, timestampUnit);
         }
 
         public Map<String, ?> fields() {
@@ -232,10 +279,11 @@ public final class MockSpan implements Span {
         }
     }
 
-    MockSpan(MockTracer tracer, String operationName, long startMicros, Map<String, Object> initialTags, MockContext parent) {
+    MockSpan(MockTracer tracer, String operationName, long startTimestamp, TimeUnit startUnit, Map<String, Object> initialTags, MockContext parent) {
         this.mockTracer = tracer;
         this.operationName = operationName;
-        this.startMicros = startMicros;
+        this.startTimestamp = startTimestamp;
+        this.startUnit = startUnit;
         if (initialTags == null) {
             this.tags = new HashMap<>();
         } else {
@@ -256,8 +304,8 @@ public final class MockSpan implements Span {
         return nextId.addAndGet(1);
     }
 
-    static long nowMicros() {
-        return System.currentTimeMillis() * 1000;
+    static long nowMillis() {
+        return System.currentTimeMillis();
     }
 
     private synchronized void finishedCheck(String format, Object... args) {

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockSpanTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockSpanTest.java
@@ -13,15 +13,76 @@
  */
 package io.opentracing.mock;
 
+import io.opentracing.Span;
 import org.junit.Assert;
 import org.junit.Test;
 
-import io.opentracing.Span;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Pavol Loffay
  */
 public class MockSpanTest {
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testExplicitStartInMicroseconds() {
+        MockTracer tracer = new MockTracer();
+        long now = System.currentTimeMillis() * 1000;
+        Span span = tracer.buildSpan("foo")
+                .withStartTimestamp(now)
+                .startManual();
+        span.finish();
+
+        Assert.assertEquals(now, tracer.finishedSpans().get(0).startMicros());
+    }
+
+    @Test
+    public void testExplicitStart() {
+        MockTracer tracer = new MockTracer();
+        long now = System.currentTimeMillis();
+        Span span = tracer.buildSpan("foo")
+                .withStartTimestamp(now, TimeUnit.MILLISECONDS)
+                .startManual();
+        span.finish();
+
+        Assert.assertEquals(now, tracer.finishedSpans().get(0).startTimestamp(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testExplicitFinishInMicroseconds() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").startManual();
+        long finishTime = 133L;
+        span.finish(finishTime);
+
+        try {
+            span.setOperationName("bar");
+            Assert.fail();
+        } catch (RuntimeException ex) {
+            // Fall through
+        }
+        Assert.assertEquals(finishTime, tracer.finishedSpans().get(0).finishMicros());
+    }
+
+    @Test
+    public void testExplicitFinish() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").startManual();
+        long finishTime = System.currentTimeMillis();
+        span.finish(finishTime, TimeUnit.MILLISECONDS);
+
+        try {
+            span.setOperationName("bar");
+            Assert.fail();
+        } catch (RuntimeException ex) {
+            // Fall through
+        }
+        Assert.assertEquals(finishTime, tracer.finishedSpans().get(0).finishTimestamp(TimeUnit.MILLISECONDS));
+    }
 
     @Test
     public void testSetOperationNameAfterFinish() {
@@ -78,4 +139,63 @@ public class MockSpanTest {
         }
         Assert.assertEquals(1, tracer.finishedSpans().get(0).generatedErrors().size());
     }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testAddLogEventTimestampInMicroseconds() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").startManual();
+        long now = System.currentTimeMillis() * 1000;
+        span.log(now, "foo");
+        span.finish();
+
+        MockSpan actual = tracer.finishedSpans().get(0);
+        MockSpan.LogEntry logEntry = actual.logEntries().get(0);
+        Assert.assertEquals(now, logEntry.timestamp(TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testAddLogEventTimestamp() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").startManual();
+        long now = System.currentTimeMillis();
+        span.log(now, TimeUnit.MILLISECONDS, "foo");
+        span.finish();
+
+        MockSpan actual = tracer.finishedSpans().get(0);
+        MockSpan.LogEntry logEntry = actual.logEntries().get(0);
+        Assert.assertEquals(now, logEntry.timestamp(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testAddLogFieldsTimestampInMicroseconds() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").startManual();
+        long now = System.currentTimeMillis() * 1000;
+        Map<String, String> fields = new HashMap<>();
+        fields.put("foo", "bar");
+        span.log(now, fields);
+        span.finish();
+
+        MockSpan actual = tracer.finishedSpans().get(0);
+        MockSpan.LogEntry logEntry = actual.logEntries().get(0);
+        Assert.assertEquals(now, logEntry.timestamp(TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testAddLogFieldsTimestamp() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").startManual();
+        long now = System.currentTimeMillis();
+        Map<String, String> fields = new HashMap<>();
+        fields.put("foo", "bar");
+        span.log(now, TimeUnit.MILLISECONDS, fields);
+        span.finish();
+
+        MockSpan actual = tracer.finishedSpans().get(0);
+        MockSpan.LogEntry logEntry = actual.logEntries().get(0);
+        Assert.assertEquals(now, logEntry.timestamp(TimeUnit.MILLISECONDS));
+    }
+
 }

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -25,6 +25,7 @@ import io.opentracing.propagation.TextMapInjectAdapter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,16 +35,16 @@ public class MockTracerTest {
         // Create and finish a root Span.
         MockTracer tracer = new MockTracer();
         {
-            Span span = tracer.buildSpan("tester").withStartTimestamp(1000).start();
+            Span span = tracer.buildSpan("tester").withStartTimestamp(1000, TimeUnit.MICROSECONDS).start();
             span.setTag("string", "foo");
             span.setTag("int", 7);
             span.log("foo");
             Map<String, Object> fields = new HashMap<>();
             fields.put("f1", 4);
             fields.put("f2", "two");
-            span.log(1002, fields);
-            span.log(1003, "event name");
-            span.finish(2000);
+            span.log(1002, TimeUnit.MICROSECONDS, fields);
+            span.log(1003, TimeUnit.MICROSECONDS, "event name");
+            span.finish(2000, TimeUnit.MICROSECONDS);
         }
         List<MockSpan> finishedSpans = tracer.finishedSpans();
 
@@ -54,8 +55,8 @@ public class MockTracerTest {
         assertEquals(0, finishedSpan.parentId());
         assertNotEquals(0, finishedSpan.context().traceId());
         assertNotEquals(0, finishedSpan.context().spanId());
-        assertEquals(1000, finishedSpan.startMicros());
-        assertEquals(2000, finishedSpan.finishMicros());
+        assertEquals(1000, finishedSpan.startTimestamp(TimeUnit.MICROSECONDS));
+        assertEquals(2000, finishedSpan.finishTimestamp(TimeUnit.MICROSECONDS));
         Map<String, Object> tags = finishedSpan.tags();
         assertEquals(2, tags.size());
         assertEquals(7, tags.get("int"));
@@ -69,13 +70,13 @@ public class MockTracerTest {
         }
         {
             MockSpan.LogEntry log = logs.get(1);
-            assertEquals(1002, log.timestampMicros());
+            assertEquals(1002, log.timestamp(TimeUnit.MICROSECONDS));
             assertEquals(4, log.fields().get("f1"));
             assertEquals("two", log.fields().get("f2"));
         }
         {
             MockSpan.LogEntry log = logs.get(2);
-            assertEquals(1003, log.timestampMicros());
+            assertEquals(1003, log.timestamp(TimeUnit.MICROSECONDS));
             assertEquals("event name", log.fields().get("event"));
         }
     }
@@ -85,10 +86,10 @@ public class MockTracerTest {
         // Create and finish a root Span.
         MockTracer tracer = new MockTracer();
         {
-            Span parent = tracer.buildSpan("parent").withStartTimestamp(1000).start();
-            Span child = tracer.buildSpan("child").withStartTimestamp(1100).asChildOf(parent).start();
-            child.finish(1900);
-            parent.finish(2000);
+            Span parent = tracer.buildSpan("parent").withStartTimestamp(1000, TimeUnit.MICROSECONDS).start();
+            Span child = tracer.buildSpan("child").withStartTimestamp(1100, TimeUnit.MICROSECONDS).asChildOf(parent).start();
+            child.finish(1900, TimeUnit.MICROSECONDS);
+            parent.finish(2000, TimeUnit.MICROSECONDS);
         }
         List<MockSpan> finishedSpans = tracer.finishedSpans();
 
@@ -106,23 +107,24 @@ public class MockTracerTest {
     @Test
     public void testStartTimestamp() throws InterruptedException {
         MockTracer tracer = new MockTracer();
-        long startMicros;
+        long startTimestamp;
         {
             Tracer.SpanBuilder fooSpan = tracer.buildSpan("foo");
             Thread.sleep(2);
-            startMicros = System.currentTimeMillis() * 1000;
+            startTimestamp = System.currentTimeMillis() * 1000L;
             fooSpan.start().finish();
         }
         List<MockSpan> finishedSpans = tracer.finishedSpans();
 
         Assert.assertEquals(1, finishedSpans.size());
         MockSpan span = finishedSpans.get(0);
-        Assert.assertTrue(startMicros <= span.startMicros());
-        Assert.assertTrue(System.currentTimeMillis() * 1000 >= span.finishMicros());
+        Assert.assertTrue(startTimestamp <= span.startTimestamp(TimeUnit.MICROSECONDS));
+        Assert.assertTrue(System.currentTimeMillis() >= span.finishTimestamp(TimeUnit.MILLISECONDS));
     }
 
     @Test
-    public void testStartExplicitTimestamp() throws InterruptedException {
+    @SuppressWarnings("deprecation")
+    public void testStartExplicitTimestampInMicroseconds() throws InterruptedException {
         MockTracer tracer = new MockTracer();
         long startMicros = 2000;
         {
@@ -134,7 +136,24 @@ public class MockTracerTest {
         List<MockSpan> finishedSpans = tracer.finishedSpans();
 
         Assert.assertEquals(1, finishedSpans.size());
-        Assert.assertEquals(startMicros, finishedSpans.get(0).startMicros());
+        Assert.assertEquals(startMicros, finishedSpans.get(0).startTimestamp(TimeUnit.MICROSECONDS));
+    }
+
+    @Test
+    public void testStartExplicitTimestamp() throws InterruptedException {
+        MockTracer tracer = new MockTracer();
+        long startMicros = 2000;
+        TimeUnit startUnit = TimeUnit.MICROSECONDS;
+        {
+            tracer.buildSpan("foo")
+                    .withStartTimestamp(startMicros, startUnit)
+                    .start()
+                    .finish();
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        Assert.assertEquals(1, finishedSpans.size());
+        Assert.assertEquals(startMicros, finishedSpans.get(0).startTimestamp(startUnit));
     }
 
     @Test

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
@@ -17,6 +17,7 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public interface NoopSpan extends Span {
     static final NoopSpan INSTANCE = new NoopSpanImpl();
@@ -31,7 +32,11 @@ final class NoopSpanImpl implements NoopSpan {
     public void finish() {}
 
     @Override
+    @Deprecated
     public void finish(long finishMicros) {}
+
+    @Override
+    public void finish(long finishTimestamp, TimeUnit finishUnit) {}
 
     @Override
     public NoopSpan setTag(String key, String value) { return this; }
@@ -46,13 +51,22 @@ final class NoopSpanImpl implements NoopSpan {
     public NoopSpan log(Map<String, ?> fields) { return this; }
 
     @Override
+    @Deprecated
     public NoopSpan log(long timestampMicroseconds, Map<String, ?> fields) { return this; }
+
+    @Override
+    @Deprecated
+    public NoopSpan log(long timestamp, TimeUnit timeUnit, Map<String, ?> fields) { return this; }
 
     @Override
     public NoopSpan log(String event) { return this; }
 
     @Override
+    @Deprecated
     public NoopSpan log(long timestampMicroseconds, String event) { return this; }
+
+    @Override
+    public NoopSpan log(long timestamp, TimeUnit timestampUnit, String event) { return this; }
 
     @Override
     public NoopSpan setBaggageItem(String key, String value) { return this; }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
@@ -20,6 +20,7 @@ import io.opentracing.Tracer;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public interface NoopSpanBuilder extends Tracer.SpanBuilder, NoopSpanContext {
     static final NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
@@ -61,7 +62,13 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
     }
 
     @Override
+    @Deprecated
     public Tracer.SpanBuilder withStartTimestamp(long microseconds) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withStartTimestamp(long startTimestamp, TimeUnit startUnit) {
         return this;
     }
 


### PR DESCRIPTION
Adds the specification of TimeUnit to the API in places which
previously required supplying values in microseconds.