### PR TITLE
Add MDC support for basic ThreadLocalActiveSpan

### DIFF
--- a/opentracing-util/pom.xml
+++ b/opentracing-util/pom.xml
@@ -34,6 +34,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>opentracing-api</artifactId>
         </dependency>

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpanSource.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalActiveSpanSource.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @see Tracer#activeSpan()
  */
 public class ThreadLocalActiveSpanSource implements ActiveSpanSource {
+
     final ThreadLocal<ThreadLocalActiveSpan> tlsSnapshot = new ThreadLocal<ThreadLocalActiveSpan>();
 
     @Override

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalActiveSpanTest.java
@@ -68,6 +68,7 @@ public class ThreadLocalActiveSpanTest {
 
         //back in main thread it should restore the MDC
         assertEquals(MDC.get("thread"), null);
+        assertEquals(MDC.get("main"), "a");
 
     }
 

--- a/opentracing-util/src/test/java/org/slf4j/impl/StaticMDCBinder.java
+++ b/opentracing-util/src/test/java/org/slf4j/impl/StaticMDCBinder.java
@@ -1,0 +1,28 @@
+package org.slf4j.impl;
+
+import org.slf4j.helpers.BasicMDCAdapter;
+import org.slf4j.helpers.NOPMDCAdapter;
+import org.slf4j.spi.MDCAdapter;
+
+/**
+ * This is so we can test MDC functionality without having to pull in logback/log4j/log4j2
+ * We cannot use slf4j-simple because it uses a no-op implementation of MDC
+ */
+public class StaticMDCBinder {
+    public static final StaticMDCBinder SINGLETON = new StaticMDCBinder();
+
+    private StaticMDCBinder() {
+    }
+
+    public static final StaticMDCBinder getSingleton() {
+        return SINGLETON;
+    }
+
+    public MDCAdapter getMDCA() {
+        return new BasicMDCAdapter();
+    }
+
+    public String getMDCAdapterClassStr() {
+        return BasicMDCAdapter.class.getName();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <mockito.version>1.10.19</mockito.version>
         <awaitility.version>3.0.0</awaitility.version>
         <logback.version>1.2.3</logback.version>
+        <slf4j.version>1.7.25</slf4j.version>
 
         <animal-sniffer-maven-plugin.version>1.15</animal-sniffer-maven-plugin.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
@@ -120,7 +121,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.25</version>
+                <version>${slf4j.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,12 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.25</version>
+            </dependency>
+
+            <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>opentracing-api</artifactId>
                 <version>${project.version}</version>
@@ -185,6 +191,7 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
The documentation heavily mentions MDC in the interfaces but fails to
provide an example in the basic implementations of
ThreadLocalActiveSpan.

This commit adds this functionality via SLF4J which is a very popular
facade to many common logging libraries. As a result, a new dependency
is introduced on slf4j-api however I believe this to be a useful
dependency so that logging can be applied in a runtime agnostic fashion
if additional example implementations would like to be provided.

Fixes #201