### PR TITLE
Debug ID in MDC

### DIFF
--- a/opentracing-examples/README.md
+++ b/opentracing-examples/README.md
@@ -16,4 +16,5 @@ It shows continuation as a solution to finish span when last action is completed
 - **listener_per_request** - one listener per request
 - **multiple_callbacks** - many callbacks spawned at the same time
 - **nested_callbacks** - one callback at the time, defined in a pipeline fashion
+- **slf4j_mdc_debug_id** - keep debug_id of the active Span inside MDC
 

--- a/opentracing-examples/src/test/java/io/opentracing/examples/slf4j_mdc_debug_id/SimpleMdcScopeManager.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/slf4j_mdc_debug_id/SimpleMdcScopeManager.java
@@ -33,9 +33,9 @@ public class SimpleMdcScopeManager implements ScopeManager {
     }
 
     /**
-     * @param mdcKey        MDC key which value will be set to debug_id
+     * @param mdcKey  MDC key which value will be set to debug_id
      * @param debugId debug_id provider - specific to a Tracer implementation
-     * @param wrapped       ScopeManager to wrap
+     * @param wrapped ScopeManager to wrap
      */
     public SimpleMdcScopeManager(String mdcKey, DebugIdProvider debugId, ScopeManager wrapped) {
         this.mdcKey = mdcKey;

--- a/opentracing-examples/src/test/java/io/opentracing/examples/slf4j_mdc_debug_id/SimpleMdcScopeManager.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/slf4j_mdc_debug_id/SimpleMdcScopeManager.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.examples.slf4j_mdc_debug_id;
 
 import io.opentracing.Scope;

--- a/opentracing-examples/src/test/java/io/opentracing/examples/slf4j_mdc_debug_id/SimpleMdcScopeManager.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/slf4j_mdc_debug_id/SimpleMdcScopeManager.java
@@ -1,0 +1,74 @@
+package io.opentracing.examples.slf4j_mdc_debug_id;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import org.slf4j.MDC;
+
+/**
+ * Puts debug_id into MDC when scope is activated. When the active scope closes restores the previous value.
+ * It's designed to work with ThreadLocalScopeManager. For this ScopeManager to work scope must be activated and closed
+ * inside the same thread - ideally using try-finally or try-with-resource.
+ */
+public class SimpleMdcScopeManager implements ScopeManager {
+    private final String mdcKey;
+    private final ScopeManager wrapped;
+    private final DebugIdProvider debugId;
+
+    interface DebugIdProvider {
+        String get(Span span);
+    }
+
+    /**
+     * @param mdcKey        MDC key which value will be set to debug_id
+     * @param debugId debug_id provider - specific to a Tracer implementation
+     * @param wrapped       ScopeManager to wrap
+     */
+    public SimpleMdcScopeManager(String mdcKey, DebugIdProvider debugId, ScopeManager wrapped) {
+        this.mdcKey = mdcKey;
+        this.wrapped = wrapped;
+        this.debugId = debugId;
+    }
+
+    @Override
+    public Scope activate(Span span) {
+        return activate(span, true);
+    }
+
+    @Override
+    public Scope activate(Span span, boolean finishSpanOnClose) {
+        Scope scope = wrapped.activate(span, finishSpanOnClose);
+        String debugId = MDC.get(mdcKey);
+        MDC.put(mdcKey, this.debugId.get(span));
+        return new MdcScope(scope, debugId);
+    }
+
+    @Override
+    public Scope active() {
+        return wrapped.active();
+    }
+
+    class MdcScope implements Scope {
+        private final Scope wrapped;
+        private final String previousDebugId;
+
+        MdcScope(Scope wrapped, String previousDebugId) {
+            this.wrapped = wrapped;
+            this.previousDebugId = previousDebugId;
+        }
+
+        @Override
+        public void close() {
+            try {
+                wrapped.close();
+            } finally {
+                MDC.put(mdcKey, previousDebugId);
+            }
+        }
+
+        @Override
+        public Span span() {
+            return wrapped.span();
+        }
+    }
+}

--- a/opentracing-examples/src/test/java/io/opentracing/examples/slf4j_mdc_debug_id/SimpleMdcScopeManagerTest.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/slf4j_mdc_debug_id/SimpleMdcScopeManagerTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.examples.slf4j_mdc_debug_id;
 
 import io.opentracing.Scope;

--- a/opentracing-examples/src/test/java/io/opentracing/examples/slf4j_mdc_debug_id/SimpleMdcScopeManagerTest.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/slf4j_mdc_debug_id/SimpleMdcScopeManagerTest.java
@@ -1,0 +1,89 @@
+package io.opentracing.examples.slf4j_mdc_debug_id;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalScopeManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class SimpleMdcScopeManagerTest {
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private MockTracer tracer;
+
+    @Before
+    public void setup() {
+        ScopeManager scopeManager = new SimpleMdcScopeManager("debug_id",
+                new MockSpanDebugId(), new ThreadLocalScopeManager());
+        tracer = new MockTracer(scopeManager, MockTracer.Propagator.TEXT_MAP);
+    }
+
+    @Before
+    @After
+    public void clear() {
+        MDC.clear();
+    }
+
+    @Test
+    public void puts_debug_id_when_scope_activates() {
+        Scope scope = tracer.buildSpan("op").startActive();
+
+        assertThat(MDC.get("debug_id"), equalTo(getDebugId(scope.span())));
+    }
+
+    @Test
+    public void removes_debug_id_when_scope_closes() {
+        try (Scope ignore = tracer.buildSpan("op").startActive()) {
+            assertThat(MDC.get("debug_id"), notNullValue());
+        }
+        assertThat(MDC.get("debug_id"), equalTo(null));
+    }
+
+    @Test
+    public void tracks_debug_id_of_innermost_scope() {
+        try (Scope outer = tracer.buildSpan("outer").startActive()) {
+            String outerId = getDebugId(outer.span());
+            assertThat(MDC.get("debug_id"), equalTo(outerId));
+
+            try (Scope middle = tracer.buildSpan("middle").startActive()) {
+                String middleId = getDebugId(middle.span());
+                assertThat(MDC.get("debug_id"), equalTo(middleId));
+
+                try (Scope inner = tracer.buildSpan("inner").startActive()) {
+                    String innerId = getDebugId(inner.span());
+                    assertThat(MDC.get("debug_id"), equalTo(innerId));
+                }
+
+                assertThat(MDC.get("debug_id"), equalTo(middleId));
+            }
+
+            assertThat(MDC.get("debug_id"), equalTo(outerId));
+        }
+
+        assertThat(MDC.get("debug_id"), equalTo(null));
+    }
+
+    private static String getDebugId(Span span) {
+        MockSpan.MockContext ctx = ((MockSpan) span).context();
+        return ctx.traceId() + ":" + ctx.spanId();
+    }
+
+    private static class MockSpanDebugId implements SimpleMdcScopeManager.DebugIdProvider {
+        @Override
+        public String get(Span span) {
+            MockSpan.MockContext ctx = ((MockSpan) span).context();
+            return ctx.traceId() + ":" + ctx.spanId();
+        }
+    }
+}


### PR DESCRIPTION
An example of keeping Span's debug_id inside MDC - for version 0.31.0+

Puts active Spans's debug_id when scope is activated and cleans it
afterwards.

see also: https://github.com/opentracing/opentracing-java/issues/206