### PR TITLE
Add Span#unwrap

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/Span.java
@@ -161,4 +161,21 @@ public interface Span {
      * @see Span#context()
      */
     void finish(long finishMicros);
+
+    /**
+     * Returns an object that is an instance of the given class to allow access to non-standard methods.
+     *
+     * <p> Using this method is highly preferred to type casts, especially because there might be a hierarchy of wrapper
+     * objects. </p>
+     *
+     * <p> If the class implementing this interface is an instance of the provided class, the <code>this</code>
+     * reference is returned. Otherwise, if the receiver is a wrapper, return the the result of calling
+     * <code>unwrap</code> recursively on the wrapped object. If the receiver is not a wrapper and is not an instance of
+     * the provided class, then <code>null</code> is returned.</p>
+     *
+     * @param clazz The Class that the result must be an instance of.
+     * @return an object that is an instance of the provided class, or <code>null</code> if there is no such class in
+     * the wrapper hierarchy.
+     */
+    <T> T unwrap(java.lang.Class<T> clazz);
 }


### PR DESCRIPTION
With `Span` wrappers becoming more and more popular (for example https://github.com/opentracing-contrib/java-api-extensions). There is a [growing need](https://github.com/openzipkin-contrib/brave-opentracing/blob/0869a9245aa78d5c9aafb71e16e7a130faf3547f/src/main/java/brave/opentracing/BraveActiveSpanSource.java#L52) to be able to get access to the underlying `Span` implementation without type casts which fail if there is a hierarchy of span wrappers.