### PR TITLE
Move our old ActiveSpan related APIs to sub v_030 packages.

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/v_030/ActiveSpan.java
+++ b/opentracing-api/src/main/java/io/opentracing/v_030/ActiveSpan.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+import io.opentracing.SpanContext;
+
+import java.io.Closeable;
+
+/**
+ * {@link ActiveSpan} inherits all of the OpenTracing functionality in {@link BaseSpan} and layers on in-process
+ * propagation capabilities.
+ *
+ * <p>
+ * In any given thread there is at most one {@link ActiveSpan "active" span} primarily responsible for the work
+ * accomplished by the surrounding application code. That {@link ActiveSpan} may be accessed via the
+ * {@link ActiveSpanSource#activeSpan()} method. If the application needs to defer work that should be part of
+ * the same Span, the Source provides a {@link ActiveSpan#capture} method that returns a {@link Continuation};
+ * this continuation may be used to re-activate and continue the {@link Span} in that other asynchronous executor
+ * and/or thread.
+ *
+ * <p>
+ * {@link ActiveSpan}s are created via {@link Tracer.SpanBuilder#startActive()} or, less commonly,
+ * {@link ActiveSpanSource#makeActive}. Per the above, they can be {@link ActiveSpan#capture()}ed as
+ * {@link ActiveSpan.Continuation}s, then re-{@link Continuation#activate()}d later.
+ *
+ * <p>
+ * NOTE: {@link ActiveSpan} extends {@link Closeable} rather than {@code AutoCloseable} in order to preserve support
+ * for JDK1.6.
+ *
+ * @see Tracer.SpanBuilder#startActive()
+ * @see Continuation#activate()
+ * @see ActiveSpanSource
+ * @see BaseSpan
+ * @see Span
+ */
+public interface ActiveSpan extends Closeable, BaseSpan<ActiveSpan> {
+    /**
+     * Mark the end of the active period for the current thread and {@link ActiveSpan}. When the last
+     * {@link ActiveSpan} is deactivated for a given {@link Span}, it is automatically {@link Span#finish()}ed.
+     *
+     * <p>
+     * NOTE: Calling {@link #deactivate} more than once on a single {@link ActiveSpan} instance leads to undefined
+     * behavior.
+     *
+     * @see Closeable#close() {@link ActiveSpan}s are auto-closeable and may be used in try-with-resources blocks
+     */
+    void deactivate();
+
+    /**
+     * A synonym for {@link #deactivate()} that can be used in try-with-resources blocks.
+     */
+    @Override
+    void close();
+
+    /**
+     * "Capture" a new {@link Continuation} associated with this {@link ActiveSpan} and {@link Span}, as well as any
+     * 3rd-party execution context of interest. The {@link Continuation} may be used as data in a closure or callback
+     * function where the {@link ActiveSpan} may be resumed and reactivated.
+     *
+     * <p>
+     * <em>IMPORTANT:</em> the caller MUST {@link Continuation#activate()} and {@link ActiveSpan#deactivate()} the
+     * returned {@link Continuation} or the associated {@link Span} will never automatically {@link Span#finish()}.
+     * That is, calling {@link #capture()} increments a refcount that must be decremented somewhere else.
+     *
+     * <p>
+     * The associated {@link Span} will not {@link Span#finish()} while a {@link Continuation} is outstanding; in
+     * this way, it provides a reference/pin just like an {@link ActiveSpan} does.
+     *
+     * @return a new {@link Continuation} to {@link Continuation#activate()} at the appropriate time.
+     */
+    Continuation capture();
+
+    /**
+     * A {@link Continuation} can be used <em>once</em> to activate a Span along with any non-OpenTracing execution
+     * context (e.g., MDC), then deactivate when processing activity moves on to another Span. (In practice, this
+     * active period typically extends for the length of a deferred async closure invocation.)
+     *
+     * <p>
+     * Most users do not directly interact with {@link Continuation}, {@link Continuation#activate()} or
+     * {@link ActiveSpan#deactivate()}, but rather use {@link ActiveSpanSource}-aware Runnables/Callables/Executors.
+     * Those higher-level primitives do not <em>need</em> to be defined within the OpenTracing core API, and so
+     * they are not.
+     *
+     * @see ActiveSpanSource#makeActive(Span)
+     */
+    interface Continuation {
+        /**
+         * Make the Span (and other execution context) encapsulated by this {@link Continuation} active and
+         * return it.
+         *
+         * <p>
+         * NOTE: It is an error to call activate() more than once on a single Continuation instance.
+         *
+         * @see ActiveSpanSource#makeActive(Span)
+         * @return a handle to the newly-activated {@link ActiveSpan}
+         */
+        ActiveSpan activate();
+    }
+
+}

--- a/opentracing-api/src/main/java/io/opentracing/v_030/ActiveSpan.java
+++ b/opentracing-api/src/main/java/io/opentracing/v_030/ActiveSpan.java
@@ -13,8 +13,6 @@
  */
 package io.opentracing.v_030;
 
-import io.opentracing.SpanContext;
-
 import java.io.Closeable;
 
 /**

--- a/opentracing-api/src/main/java/io/opentracing/v_030/ActiveSpanSource.java
+++ b/opentracing-api/src/main/java/io/opentracing/v_030/ActiveSpanSource.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+/**
+ * {@link ActiveSpanSource} allows an existing (possibly thread-local-aware) execution context provider to act as a
+ * source for an actively-scheduled OpenTracing Span.
+ *
+ * <p>
+ * {@link ActiveSpanSource} is a super-interface to {@link Tracer}, so note that all {@link Tracer}s fulfill the
+ * {@link ActiveSpanSource} contract.
+ *
+ * @see ActiveSpan
+ */
+public interface ActiveSpanSource {
+
+    /**
+     * Return the {@link ActiveSpan active span}. This does not affect the internal reference count for the
+     * {@link ActiveSpan}.
+     *
+     * <p>
+     * If there is an {@link ActiveSpan active span}, it becomes an implicit parent of any newly-created
+     * {@link BaseSpan span} at {@link Tracer.SpanBuilder#startActive()} time (rather than at
+     * {@link Tracer#buildSpan(String)} time).
+     *
+     * @return the {@link ActiveSpan active span}, or null if none could be found.
+     */
+    ActiveSpan activeSpan();
+
+    /**
+     * Wrap and "make active" a {@link Span} by encapsulating it – and any active state (e.g., MDC state) in the
+     * current thread – in a new {@link ActiveSpan}.
+     *
+     * @param span the Span to wrap in an {@link ActiveSpan}
+     * @return an {@link ActiveSpan} that encapsulates the given {@link Span} and any other
+     *     {@link ActiveSpanSource}-specific context (e.g., the MDC context map)
+     */
+    ActiveSpan makeActive(Span span);
+}

--- a/opentracing-api/src/main/java/io/opentracing/v_030/BaseSpan.java
+++ b/opentracing-api/src/main/java/io/opentracing/v_030/BaseSpan.java
@@ -13,8 +13,6 @@
  */
 package io.opentracing.v_030;
 
-import io.opentracing.SpanContext;
-
 import java.util.Map;
 
 /**

--- a/opentracing-api/src/main/java/io/opentracing/v_030/BaseSpan.java
+++ b/opentracing-api/src/main/java/io/opentracing/v_030/BaseSpan.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+import io.opentracing.SpanContext;
+
+import java.util.Map;
+
+/**
+ * {@link BaseSpan} represents the OpenTracing specification's span contract with the exception of methods to finish
+ * said span. For those, either use {@link Span#finish()} or {@link ActiveSpan#deactivate()} depending on the
+ * programming model.
+ *
+ * @see Span
+ * @see ActiveSpan
+ * @see Tracer.SpanBuilder#startManual()
+ * @see Tracer.SpanBuilder#startActive()
+ */
+public interface BaseSpan<S extends BaseSpan> {
+    /**
+     * Retrieve the associated SpanContext.
+     *
+     * This may be called at any time, including after calls to finish().
+     *
+     * @return the SpanContext that encapsulates Span state that should propagate across process boundaries.
+     */
+    SpanContext context();
+
+    /**
+     * Set a key:value tag on the Span.
+     */
+    S setTag(String key, String value);
+
+    /** Same as {@link #setTag(String, String)}, but for boolean values. */
+    S setTag(String key, boolean value);
+
+    /** Same as {@link #setTag(String, String)}, but for numeric values. */
+    S setTag(String key, Number value);
+
+    /**
+     * Log key:value pairs to the Span with the current walltime timestamp.
+     *
+     * <p><strong>CAUTIONARY NOTE:</strong> not all Tracer implementations support key:value log fields end-to-end.
+     * Caveat emptor.
+     *
+     * <p>A contrived example (using Guava, which is not required):
+     * <pre><code>
+     span.log(
+     ImmutableMap.Builder<String, Object>()
+     .put("event", "soft error")
+     .put("type", "cache timeout")
+     .put("waited.millis", 1500)
+     .build());
+     </code></pre>
+     *
+     * @param fields key:value log fields. Tracer implementations should support String, numeric, and boolean values;
+     *               some may also support arbitrary Objects.
+     * @return the Span, for chaining
+     * @see Span#log(String)
+     */
+    S log(Map<String, ?> fields);
+
+    /**
+     * Like log(Map&lt;String, Object&gt;), but with an explicit timestamp.
+     *
+     * <p><strong>CAUTIONARY NOTE:</strong> not all Tracer implementations support key:value log fields end-to-end.
+     * Caveat emptor.
+     *
+     * @param timestampMicroseconds The explicit timestamp for the log record. Must be greater than or equal to the
+     *                              Span's start timestamp.
+     * @param fields key:value log fields. Tracer implementations should support String, numeric, and boolean values;
+     *               some may also support arbitrary Objects.
+     * @return the Span, for chaining
+     * @see Span#log(long, String)
+     */
+    S log(long timestampMicroseconds, Map<String, ?> fields);
+
+    /**
+     * Record an event at the current walltime timestamp.
+     *
+     * Shorthand for
+     *
+     * <pre><code>
+     span.log(Collections.singletonMap("event", event));
+     </code></pre>
+     *
+     * @param event the event value; often a stable identifier for a moment in the Span lifecycle
+     * @return the Span, for chaining
+     */
+    S log(String event);
+
+    /**
+     * Record an event at a specific timestamp.
+     *
+     * Shorthand for
+     *
+     * <pre><code>
+     span.log(timestampMicroseconds, Collections.singletonMap("event", event));
+     </code></pre>
+     *
+     * @param timestampMicroseconds The explicit timestamp for the log record. Must be greater than or equal to the
+     *                              Span's start timestamp.
+     * @param event the event value; often a stable identifier for a moment in the Span lifecycle
+     * @return the Span, for chaining
+     */
+    S log(long timestampMicroseconds, String event);
+
+    /**
+     * Sets a baggage item in the Span (and its SpanContext) as a key/value pair.
+     *
+     * Baggage enables powerful distributed context propagation functionality where arbitrary application data can be
+     * carried along the full path of request execution throughout the system.
+     *
+     * Note 1: Baggage is only propagated to the future (recursive) children of this SpanContext.
+     *
+     * Note 2: Baggage is sent in-band with every subsequent local and remote calls, so this feature must be used with
+     * care.
+     *
+     * @return this Span instance, for chaining
+     */
+    S setBaggageItem(String key, String value);
+
+    /**
+     * @return the value of the baggage item identified by the given key, or null if no such item could be found
+     */
+    String getBaggageItem(String key);
+
+    /**
+     * Sets the string name for the logical operation this span represents.
+     *
+     * @return this Span instance, for chaining
+     */
+    S setOperationName(String operationName);
+}

--- a/opentracing-api/src/main/java/io/opentracing/v_030/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/v_030/Span.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+/**
+ * Represents an in-flight Span that's <strong>manually propagated</strong> within the given process. Most of
+ * the API lives in {@link BaseSpan}.
+ *
+ * <p>{@link Span}s are created by the {@link Tracer.SpanBuilder#startManual} method; see {@link ActiveSpan} for
+ * a {@link BaseSpan} extension designed for automatic in-process propagation.
+ *
+ * @see ActiveSpan for automatic propagation (recommended for most intstrumentation!)
+ */
+public interface Span extends BaseSpan<Span> {
+    /**
+     * Sets the end timestamp to now and records the span.
+     *
+     * <p>With the exception of calls to {@link #context}, this should be the last call made to the span instance.
+     * Future calls to {@link #finish} are defined as noops, and future calls to methods other than {@link #context}
+     * lead to undefined behavior.
+     *
+     * @see Span#context()
+     */
+    void finish();
+
+    /**
+     * Sets an explicit end timestamp and records the span.
+     *
+     * <p>With the exception of calls to Span.context(), this should be the last call made to the span instance, and to
+     * do otherwise leads to undefined behavior.
+     *
+     * @param finishMicros an explicit finish time, in microseconds since the epoch
+     *
+     * @see Span#context()
+     */
+    void finish(long finishMicros);
+}

--- a/opentracing-api/src/main/java/io/opentracing/v_030/SpanContext.java
+++ b/opentracing-api/src/main/java/io/opentracing/v_030/SpanContext.java
@@ -11,26 +11,14 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opentracing.noop.v_030;
+package io.opentracing.v_030;
 
-import io.opentracing.v_030.SpanContext;
-
-import java.util.Collections;
 import java.util.Map;
 
-
-public interface NoopSpanContext extends SpanContext {
-}
-
-final class NoopSpanContextImpl implements NoopSpanContext {
-    static final NoopSpanContextImpl INSTANCE = new NoopSpanContextImpl();
-
-    @Override
-    public Iterable<Map.Entry<String, String>> baggageItems() {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public String toString() { return NoopSpanContext.class.getSimpleName(); }
-
+/**
+ * SpanContext represents Span state that must propagate to descendant Spans and across process boundaries.
+ * This interface is the same as io.opentracing.SpanContext, as is provided under this package
+ * in order to keep API uniformity.
+ */
+public interface SpanContext extends io.opentracing.SpanContext {
 }

--- a/opentracing-api/src/main/java/io/opentracing/v_030/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/v_030/Tracer.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+
+/**
+ * Tracer is a simple, thin interface for Span creation and propagation across arbitrary transports.
+ */
+public interface Tracer extends ActiveSpanSource {
+
+    /**
+     * Return a new SpanBuilder for a Span with the given `operationName`.
+     *
+     * <p>You can override the operationName later via {@link Span#setOperationName(String)}.
+     *
+     * <p>A contrived example:
+     * <pre><code>
+     *   Tracer tracer = ...
+     *
+     *   // Note: if there is a `tracer.activeSpan()`, it will be used as the target of an implicit CHILD_OF
+     *   // Reference for "workSpan" when `startActive()` is invoked.
+     *   try (ActiveSpan workSpan = tracer.buildSpan("DoWork").startActive()) {
+     *       workSpan.setTag("...", "...");
+     *       // etc, etc
+     *   }
+     *
+     *   // It's also possible to create Spans manually, bypassing the ActiveSpanSource activation.
+     *   Span http = tracer.buildSpan("HandleHTTPRequest")
+     *                     .asChildOf(rpcSpanContext)  // an explicit parent
+     *                     .withTag("user_agent", req.UserAgent)
+     *                     .withTag("lucky_number", 42)
+     *                     .startManual();
+     * </code></pre>
+     */
+    SpanBuilder buildSpan(String operationName);
+
+    /**
+     * Inject a SpanContext into a `carrier` of a given type, presumably for propagation across process boundaries.
+     *
+     * <p>Example:
+     * <pre><code>
+     * Tracer tracer = ...
+     * Span clientSpan = ...
+     * TextMap httpHeadersCarrier = new AnHttpHeaderCarrier(httpRequest);
+     * tracer.inject(span.context(), Format.Builtin.HTTP_HEADERS, httpHeadersCarrier);
+     * </code></pre>
+     *
+     * @param <C> the carrier type, which also parametrizes the Format.
+     * @param spanContext the SpanContext instance to inject into the carrier
+     * @param format the Format of the carrier
+     * @param carrier the carrier for the SpanContext state. All Tracer.inject() implementations must support
+     *                io.opentracing.propagation.TextMap and java.nio.ByteBuffer.
+     *
+     * @see io.opentracing.propagation.Format
+     * @see io.opentracing.propagation.Format.Builtin
+     */
+    <C> void inject(SpanContext spanContext, Format<C> format, C carrier);
+
+    /**
+     * Extract a SpanContext from a `carrier` of a given type, presumably after propagation across a process boundary.
+     *
+     * <p>Example:
+     * <pre><code>
+     * Tracer tracer = ...
+     * TextMap httpHeadersCarrier = new AnHttpHeaderCarrier(httpRequest);
+     * SpanContext spanCtx = tracer.extract(Format.Builtin.HTTP_HEADERS, httpHeadersCarrier);
+     * ... = tracer.buildSpan('...').asChildOf(spanCtx).startActive();
+     * </code></pre>
+     *
+     * If the span serialized state is invalid (corrupt, wrong version, etc) inside the carrier this will result in an
+     * IllegalArgumentException.
+     *
+     * @param <C> the carrier type, which also parametrizes the Format.
+     * @param format the Format of the carrier
+     * @param carrier the carrier for the SpanContext state. All Tracer.extract() implementations must support
+     *                io.opentracing.propagation.TextMap and java.nio.ByteBuffer.
+     *
+     * @return the SpanContext instance holding context to create a Span.
+     *
+     * @see io.opentracing.propagation.Format
+     * @see io.opentracing.propagation.Format.Builtin
+     */
+    <C> SpanContext extract(Format<C> format, C carrier);
+
+
+    interface SpanBuilder {
+
+        /**
+         * A shorthand for addReference(References.CHILD_OF, parent).
+         *
+         * <p>
+         * If parent==null, this is a noop.
+         */
+        SpanBuilder asChildOf(SpanContext parent);
+
+        /**
+         * A shorthand for addReference(References.CHILD_OF, parent.context()).
+         *
+         * <p>
+         * If parent==null, this is a noop.
+         */
+        SpanBuilder asChildOf(BaseSpan<?> parent);
+
+        /**
+         * Add a reference from the Span being built to a distinct (usually parent) Span. May be called multiple times
+         * to represent multiple such References.
+         *
+         * <p>
+         * If
+         * <ul>
+         * <li>the {@link Tracer}'s {@link ActiveSpanSource#activeSpan()} is not null, and
+         * <li>no <b>explicit</b> references are added via {@link SpanBuilder#addReference}, and
+         * <li>{@link SpanBuilder#ignoreActiveSpan()} is not invoked,
+         * </ul>
+         * ... then an inferred {@link References#CHILD_OF} reference is created to the
+         * {@link ActiveSpanSource#activeSpan()} {@link SpanContext} when either {@link SpanBuilder#startActive()} or
+         * {@link SpanBuilder#startManual} is invoked.
+         *
+         * @param referenceType the reference type, typically one of the constants defined in References
+         * @param referencedContext the SpanContext being referenced; e.g., for a References.CHILD_OF referenceType, the
+         *                          referencedContext is the parent. If referencedContext==null, the call to
+         *                          {@link #addReference} is a noop.
+         *
+         * @see io.opentracing.References
+         */
+        SpanBuilder addReference(String referenceType, SpanContext referencedContext);
+
+        /**
+         * Do not create an implicit {@link References#CHILD_OF} reference to the {@link ActiveSpanSource#activeSpan}).
+         */
+        SpanBuilder ignoreActiveSpan();
+
+        /** Same as {@link Span#setTag(String, String)}, but for the span being built. */
+        SpanBuilder withTag(String key, String value);
+
+        /** Same as {@link Span#setTag(String, boolean)}, but for the span being built. */
+        SpanBuilder withTag(String key, boolean value);
+
+        /** Same as {@link Span#setTag(String, Number)}, but for the span being built. */
+        SpanBuilder withTag(String key, Number value);
+
+        /** Specify a timestamp of when the Span was started, represented in microseconds since epoch. */
+        SpanBuilder withStartTimestamp(long microseconds);
+
+        /**
+         * Returns a newly started and activated {@link ActiveSpan}.
+         *
+         * <p>
+         * The returned {@link ActiveSpan} supports try-with-resources. For example:
+         * <pre><code>
+         *     try (ActiveSpan span = tracer.buildSpan("...").startActive()) {
+         *         // (Do work)
+         *         span.setTag( ... );  // etc, etc
+         *     }  // Span finishes automatically unless deferred via {@link ActiveSpan#capture}
+         * </code></pre>
+         *
+         * <p>
+         * If
+         * <ul>
+         * <li>the {@link Tracer}'s {@link ActiveSpanSource#activeSpan()} is not null, and
+         * <li>no <b>explicit</b> references are added via {@link SpanBuilder#addReference}, and
+         * <li>{@link SpanBuilder#ignoreActiveSpan()} is not invoked,
+         * </ul>
+         * ... then an inferred {@link References#CHILD_OF} reference is created to the
+         * {@link ActiveSpanSource#activeSpan()}'s {@link SpanContext} when either
+         * {@link SpanBuilder#startManual()} or {@link SpanBuilder#startActive} is invoked.
+         *
+         * <p>
+         * Note: {@link SpanBuilder#startActive()} is a shorthand for
+         * {@code tracer.makeActive(spanBuilder.startManual())}.
+         *
+         * @return an {@link ActiveSpan}, already registered via the {@link ActiveSpanSource}
+         *
+         * @see ActiveSpanSource
+         * @see ActiveSpan
+         */
+        ActiveSpan startActive();
+
+        /**
+         * Like {@link #startActive()}, but the returned {@link Span} has not been registered via the
+         * {@link ActiveSpanSource}.
+         *
+         * @see SpanBuilder#startActive()
+         * @return the newly-started Span instance, which has *not* been automatically registered
+         *         via the {@link ActiveSpanSource}
+         */
+        Span startManual();
+
+        /**
+         * @deprecated use {@link #startManual} or {@link #startActive} instead.
+         */
+        @Deprecated
+        Span start();
+    }
+}

--- a/opentracing-api/src/main/java/io/opentracing/v_030/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/v_030/Tracer.java
@@ -13,7 +13,6 @@
  */
 package io.opentracing.v_030;
 
-import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
 
 /**

--- a/opentracing-mock/src/main/java/io/opentracing/mock/v_030/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/v_030/MockSpan.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.mock.v_030;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.opentracing.SpanContext;
+import io.opentracing.v_030.Span;
+
+/**
+ * MockSpans are created via MockTracer.buildSpan(...), but they are also returned via calls to
+ * MockTracer.finishedSpans(). They provide accessors to all Span state.
+ *
+ * @see MockTracer#finishedSpans()
+ */
+public final class MockSpan implements Span {
+    // A simple-as-possible (consecutive for repeatability) id generator.
+    private static AtomicLong nextId = new AtomicLong(0);
+
+    private final MockTracer mockTracer;
+    private MockContext context;
+    private final long parentId; // 0 if there's no parent.
+    private final long startMicros;
+    private boolean finished;
+    private long finishMicros;
+    private final Map<String, Object> tags;
+    private final List<LogEntry> logEntries = new ArrayList<>();
+    private String operationName;
+
+    private final List<RuntimeException> errors = new ArrayList<>();
+
+    public String operationName() {
+        return this.operationName;
+    }
+
+    @Override
+    public MockSpan setOperationName(String operationName) {
+        finishedCheck("Setting operationName {%s} on already finished span", operationName);
+        this.operationName = operationName;
+        return this;
+    }
+
+    /**
+     * TODO: Support multiple parents in this API.
+     *
+     * @return the spanId of the Span's parent context, or 0 if no such parent exists.
+     *
+     * @see MockContext#spanId()
+     */
+    public long parentId() {
+        return parentId;
+    }
+    public long startMicros() {
+        return startMicros;
+    }
+    /**
+     * @return the finish time of the Span; only valid after a call to finish().
+     */
+    public long finishMicros() {
+        assert finishMicros > 0 : "must call finish() before finishMicros()";
+        return finishMicros;
+    }
+
+    /**
+     * @return a copy of all tags set on this Span.
+     */
+    public Map<String, Object> tags() {
+        return new HashMap<>(this.tags);
+    }
+    /**
+     * @return a copy of all log entries added to this Span.
+     */
+    public List<LogEntry> logEntries() {
+        return new ArrayList<>(this.logEntries);
+    }
+
+    /**
+     * @return a copy of exceptions thrown by this class (e.g. adding a tag after span is finished).
+     */
+    public List<RuntimeException> generatedErrors() {
+        return new ArrayList<>(errors);
+    }
+
+    @Override
+    public synchronized MockContext context() {
+        return this.context;
+    }
+
+    @Override
+    public void finish() {
+        this.finish(nowMicros());
+    }
+
+    @Override
+    public synchronized void finish(long finishMicros) {
+        finishedCheck("Finishing already finished span");
+        this.finishMicros = finishMicros;
+        this.mockTracer.appendFinishedSpan(this);
+        this.finished = true;
+    }
+
+    @Override
+    public MockSpan setTag(String key, String value) {
+        return setObjectTag(key, value);
+    }
+
+    @Override
+    public MockSpan setTag(String key, boolean value) {
+        return setObjectTag(key, value);
+    }
+
+    @Override
+    public MockSpan setTag(String key, Number value) {
+        return setObjectTag(key, value);
+    }
+
+    private synchronized MockSpan setObjectTag(String key, Object value) {
+        finishedCheck("Adding tag {%s:%s} to already finished span", key, value);
+        tags.put(key, value);
+        return this;
+    }
+
+    @Override
+    public final Span log(Map<String, ?> fields) {
+        return log(nowMicros(), fields);
+    }
+
+    @Override
+    public final synchronized MockSpan log(long timestampMicros, Map<String, ?> fields) {
+        finishedCheck("Adding logs %s at %d to already finished span", fields, timestampMicros);
+        this.logEntries.add(new LogEntry(timestampMicros, fields));
+        return this;
+    }
+
+    @Override
+    public MockSpan log(String event) {
+        return this.log(nowMicros(), event);
+    }
+
+    @Override
+    public MockSpan log(long timestampMicroseconds, String event) {
+        return this.log(timestampMicroseconds, Collections.singletonMap("event", event));
+    }
+
+    @Override
+    public synchronized Span setBaggageItem(String key, String value) {
+        finishedCheck("Adding baggage {%s:%s} to already finished span", key, value);
+        this.context = this.context.withBaggageItem(key, value);
+        return this;
+    }
+
+    @Override
+    public synchronized String getBaggageItem(String key) {
+        return this.context.getBaggageItem(key);
+    }
+
+    /**
+     * MockContext implements a Dapper-like opentracing.SpanContext with a trace- and span-id.
+     *
+     * Note that parent ids are part of the MockSpan, not the MockContext (since they do not need to propagate
+     * between processes).
+     */
+    public static final class MockContext implements SpanContext {
+        private final long traceId;
+        private final Map<String, String> baggage;
+        private final long spanId;
+
+        /**
+         * A package-protected constructor to create a new MockContext. This should only be called by MockSpan and/or
+         * MockTracer.
+         *
+         * @param baggage the MockContext takes ownership of the baggage parameter
+         *
+         * @see MockContext#withBaggageItem(String, String)
+         */
+        public MockContext(long traceId, long spanId, Map<String, String> baggage) {
+            this.baggage = baggage;
+            this.traceId = traceId;
+            this.spanId = spanId;
+        }
+
+        public String getBaggageItem(String key) { return this.baggage.get(key); }
+        public long traceId() { return traceId; }
+        public long spanId() { return spanId; }
+
+        /**
+         * Create and return a new (immutable) MockContext with the added baggage item.
+         */
+        public MockContext withBaggageItem(String key, String val) {
+            Map<String, String> newBaggage = new HashMap<>(this.baggage);
+            newBaggage.put(key, val);
+            return new MockContext(this.traceId, this.spanId, newBaggage);
+        }
+
+        @Override
+        public Iterable<Map.Entry<String, String>> baggageItems() {
+            return baggage.entrySet();
+        }
+    }
+
+    public static final class LogEntry {
+        private final long timestampMicros;
+        private final Map<String, ?> fields;
+
+        public LogEntry(long timestampMicros, Map<String, ?> fields) {
+            this.timestampMicros = timestampMicros;
+            this.fields = fields;
+        }
+
+        public long timestampMicros() {
+            return timestampMicros;
+        }
+
+        public Map<String, ?> fields() {
+            return fields;
+        }
+    }
+
+    MockSpan(MockTracer tracer, String operationName, long startMicros, Map<String, Object> initialTags, MockContext parent) {
+        this.mockTracer = tracer;
+        this.operationName = operationName;
+        this.startMicros = startMicros;
+        if (initialTags == null) {
+            this.tags = new HashMap<>();
+        } else {
+            this.tags = new HashMap<>(initialTags);
+        }
+        if (parent == null) {
+            // We're a root Span.
+            this.context = new MockContext(nextId(), nextId(), new HashMap<String, String>());
+            this.parentId = 0;
+        } else {
+            // We're a child Span.
+            this.context = new MockContext(parent.traceId, nextId(), parent.baggage);
+            this.parentId = parent.spanId;
+        }
+    }
+
+    static long nextId() {
+        return nextId.addAndGet(1);
+    }
+
+    static long nowMicros() {
+        return System.currentTimeMillis() * 1000;
+    }
+
+    private synchronized void finishedCheck(String format, Object... args) {
+        if (finished) {
+            RuntimeException ex = new IllegalStateException(String.format(format, args));
+            errors.add(ex);
+            throw ex;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+                "traceId:" + context.traceId() +
+                ", spanId:" + context.spanId() +
+                ", parentId:" + parentId +
+                ", operationName:\"" + operationName + "\"}";
+    }
+}

--- a/opentracing-mock/src/main/java/io/opentracing/mock/v_030/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/v_030/MockSpan.java
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import io.opentracing.SpanContext;
 import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
 
 /**
  * MockSpans are created via MockTracer.buildSpan(...), but they are also returned via calls to

--- a/opentracing-mock/src/main/java/io/opentracing/mock/v_030/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/v_030/MockTracer.java
@@ -14,13 +14,13 @@
 package io.opentracing.mock.v_030;
 
 import io.opentracing.References;
-import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.v_030.ActiveSpan;
 import io.opentracing.v_030.ActiveSpanSource;
 import io.opentracing.v_030.BaseSpan;
 import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
 import io.opentracing.v_030.Tracer;
 import io.opentracing.noop.v_030.NoopActiveSpanSource;
 import io.opentracing.util.v_030.ThreadLocalActiveSpanSource;

--- a/opentracing-mock/src/main/java/io/opentracing/mock/v_030/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/v_030/MockTracer.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.mock.v_030;
+
+import io.opentracing.References;
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMap;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.ActiveSpanSource;
+import io.opentracing.v_030.BaseSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.noop.v_030.NoopActiveSpanSource;
+import io.opentracing.util.v_030.ThreadLocalActiveSpanSource;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MockTracer makes it easy to test the semantics of OpenTracing instrumentation.
+ *
+ * By using a MockTracer as an io.opentracing.v_030.Tracer implementation for unittests, a developer can assert that Span
+ * properties and relationships with other Spans are defined as expected by instrumentation code.
+ *
+ * The MockTracerTest has simple usage examples.
+ */
+public class MockTracer implements Tracer {
+    private List<MockSpan> finishedSpans = new ArrayList<>();
+    private final Propagator propagator;
+    private ActiveSpanSource spanSource;
+
+    public MockTracer() {
+        this(new ThreadLocalActiveSpanSource(), Propagator.PRINTER);
+    }
+
+    public MockTracer(ActiveSpanSource spanSource) {
+        this(spanSource, Propagator.PRINTER);
+    }
+
+    public MockTracer(ActiveSpanSource spanSource, Propagator propagator) {
+        this.propagator = propagator;
+        this.spanSource = spanSource;
+    }
+
+    /**
+     * Create a new MockTracer that passes through any calls to inject() and/or extract().
+     */
+    public MockTracer(Propagator propagator) {
+        this(NoopActiveSpanSource.INSTANCE, propagator);
+    }
+
+    /**
+     * Clear the finishedSpans() queue.
+     *
+     * Note that this does *not* have any effect on Spans created by MockTracer that have not finish()ed yet; those
+     * will still be enqueued in finishedSpans() when they finish().
+     */
+    public synchronized void reset() {
+        this.finishedSpans.clear();
+    }
+
+    /**
+     * @return a copy of all finish()ed MockSpans started by this MockTracer (since construction or the last call to
+     * MockTracer.reset()).
+     *
+     * @see MockTracer#reset()
+     */
+    public synchronized List<MockSpan> finishedSpans() {
+        return new ArrayList<>(this.finishedSpans);
+    }
+
+    /**
+     * Noop method called on {@link Span#finish()}.
+     */
+    protected void onSpanFinished(MockSpan mockSpan) {
+    }
+
+    @Override
+    public ActiveSpan activeSpan() {
+        return spanSource.activeSpan();
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        return spanSource.makeActive(span);
+    }
+
+    /**
+     * Propagator allows the developer to intercept and verify any calls to inject() and/or extract().
+     *
+     * By default, MockTracer uses Propagator.PRINTER which simply logs such calls to System.out.
+     *
+     * @see MockTracer#MockTracer(Propagator)
+     */
+    public interface Propagator {
+        <C> void inject(MockSpan.MockContext ctx, Format<C> format, C carrier);
+        <C> MockSpan.MockContext extract(Format<C> format, C carrier);
+
+        Propagator PRINTER = new Propagator() {
+            @Override
+            public <C> void inject(MockSpan.MockContext ctx, Format<C> format, C carrier) {
+                System.out.println("inject(" + ctx + ", " + format + ", " + carrier + ")");
+            }
+
+            @Override
+            public <C> MockSpan.MockContext extract(Format<C> format, C carrier) {
+                System.out.println("extract(" + format + ", " + carrier + ")");
+                return null;
+            }
+        };
+
+        Propagator TEXT_MAP = new Propagator() {
+            public static final String SPAN_ID_KEY = "spanid";
+            public static final String TRACE_ID_KEY = "traceid";
+            public static final String BAGGAGE_KEY_PREFIX = "baggage-";
+
+            @Override
+            public <C> void inject(MockSpan.MockContext ctx, Format<C> format, C carrier) {
+                if (carrier instanceof TextMap) {
+                    TextMap textMap = (TextMap) carrier;
+                    for (Map.Entry<String, String> entry : ctx.baggageItems()) {
+                        textMap.put(BAGGAGE_KEY_PREFIX + entry.getKey(), entry.getValue());
+                    }
+                    textMap.put(SPAN_ID_KEY, String.valueOf(ctx.spanId()));
+                    textMap.put(TRACE_ID_KEY, String.valueOf(ctx.traceId()));
+                } else {
+                    throw new IllegalArgumentException("Unknown carrier");
+                }
+            }
+
+            @Override
+            public <C> MockSpan.MockContext extract(Format<C> format, C carrier) {
+                Long traceId = null;
+                Long spanId = null;
+                Map<String, String> baggage = new HashMap<>();
+
+                if (carrier instanceof TextMap) {
+                    TextMap textMap = (TextMap) carrier;
+                    for (Map.Entry<String, String> entry : textMap) {
+                        if (TRACE_ID_KEY.equals(entry.getKey())) {
+                            traceId = Long.valueOf(entry.getValue());
+                        } else if (SPAN_ID_KEY.equals(entry.getKey())) {
+                            spanId = Long.valueOf(entry.getValue());
+                        } else if (entry.getKey().startsWith(BAGGAGE_KEY_PREFIX)){
+                            String key = entry.getKey().substring((BAGGAGE_KEY_PREFIX.length()));
+                            baggage.put(key, entry.getValue());
+                        }
+                    }
+                } else {
+                    throw new IllegalArgumentException("Unknown carrier");
+                }
+
+                if (traceId != null && spanId != null) {
+                    return new MockSpan.MockContext(traceId, spanId, baggage);
+                }
+
+                return null;
+            }
+        };
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) {
+        return new SpanBuilder(operationName);
+    }
+
+    private SpanContext activeSpanContext() {
+        ActiveSpan handle = this.spanSource.activeSpan();
+        if (handle == null) {
+            return null;
+        }
+
+        return handle.context();
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+        this.propagator.inject((MockSpan.MockContext)spanContext, format, carrier);
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        return this.propagator.extract(format, carrier);
+    }
+
+    synchronized void appendFinishedSpan(MockSpan mockSpan) {
+        this.finishedSpans.add(mockSpan);
+        this.onSpanFinished(mockSpan);
+    }
+
+    public final class SpanBuilder implements Tracer.SpanBuilder {
+        private final String operationName;
+        private long startMicros;
+        private MockSpan.MockContext firstParent;
+        private boolean ignoringActiveSpan;
+        private Map<String, Object> initialTags = new HashMap<>();
+
+        SpanBuilder(String operationName) {
+            this.operationName = operationName;
+        }
+
+        @Override
+        public SpanBuilder asChildOf(SpanContext parent) {
+            return addReference(References.CHILD_OF, parent);
+        }
+
+        @Override
+        public SpanBuilder asChildOf(BaseSpan parent) {
+            return addReference(References.CHILD_OF, parent.context());
+        }
+
+        @Override
+        public SpanBuilder ignoreActiveSpan() {
+            ignoringActiveSpan = true;
+            return this;
+        }
+
+        @Override
+        public SpanBuilder addReference(String referenceType, SpanContext referencedContext) {
+            if (firstParent == null && (
+                    referenceType.equals(References.CHILD_OF) || referenceType.equals(References.FOLLOWS_FROM))) {
+                this.firstParent = (MockSpan.MockContext)referencedContext;
+            }
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withTag(String key, String value) {
+            this.initialTags.put(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withTag(String key, boolean value) {
+            this.initialTags.put(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withTag(String key, Number value) {
+            this.initialTags.put(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withStartTimestamp(long microseconds) {
+            this.startMicros = microseconds;
+            return this;
+        }
+
+        @Override
+        public MockSpan start() {
+            return startManual();
+        }
+
+        @Override
+        public ActiveSpan startActive() {
+            MockSpan span = this.startManual();
+            return spanSource.makeActive(span);
+        }
+
+        @Override
+        public MockSpan startManual() {
+            if (this.startMicros == 0) {
+                this.startMicros = MockSpan.nowMicros();
+            }
+            if (firstParent == null && !ignoringActiveSpan) {
+                firstParent = (MockSpan.MockContext) activeSpanContext();
+            }
+            return new MockSpan(MockTracer.this, operationName, startMicros, initialTags, firstParent);
+        }
+    }
+}

--- a/opentracing-mock/src/test/java/io/opentracing/mock/v_030/MockSpanTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/v_030/MockSpanTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.mock.v_030;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.opentracing.v_030.Span;
+
+/**
+ * @author Pavol Loffay
+ */
+public class MockSpanTest {
+
+    @Test
+    public void testSetOperationNameAfterFinish() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").start();
+        span.finish();
+
+        try {
+            span.setOperationName("bar");
+            Assert.fail();
+        } catch (RuntimeException ex) {
+        }
+        Assert.assertEquals(1, tracer.finishedSpans().get(0).generatedErrors().size());
+    }
+
+    @Test
+    public void testSetTagAfterFinish() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").start();
+        span.finish();
+
+        try {
+            span.setTag("bar", "foo");
+            Assert.fail();
+        } catch (RuntimeException ex) {
+        }
+        Assert.assertEquals(1, tracer.finishedSpans().get(0).generatedErrors().size());
+    }
+
+    @Test
+    public void testAddLogAfterFinish() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").start();
+        span.finish();
+
+        try {
+            span.log("bar");
+            Assert.fail();
+        } catch (RuntimeException ex) {
+        }
+        Assert.assertEquals(1, tracer.finishedSpans().get(0).generatedErrors().size());
+    }
+
+    @Test
+    public void testAddBaggageAfterFinish() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").start();
+        span.finish();
+
+        try {
+            span.setBaggageItem("foo", "bar");
+            Assert.fail();
+        } catch (RuntimeException ex) {
+        }
+        Assert.assertEquals(1, tracer.finishedSpans().get(0).generatedErrors().size());
+    }
+}

--- a/opentracing-mock/src/test/java/io/opentracing/mock/v_030/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/v_030/MockTracerTest.java
@@ -16,11 +16,11 @@ package io.opentracing.mock.v_030;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMapExtractAdapter;
 import io.opentracing.propagation.TextMapInjectAdapter;
 import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
 import io.opentracing.v_030.Tracer;
 import java.util.HashMap;
 import java.util.List;

--- a/opentracing-mock/src/test/java/io/opentracing/mock/v_030/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/v_030/MockTracerTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.mock.v_030;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMapExtractAdapter;
+import io.opentracing.propagation.TextMapInjectAdapter;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.Tracer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MockTracerTest {
+    @Test
+    public void testRootSpan() {
+        // Create and finish a root Span.
+        MockTracer tracer = new MockTracer();
+        {
+            Span span = tracer.buildSpan("tester").withStartTimestamp(1000).start();
+            span.setTag("string", "foo");
+            span.setTag("int", 7);
+            span.log("foo");
+            Map<String, Object> fields = new HashMap<>();
+            fields.put("f1", 4);
+            fields.put("f2", "two");
+            span.log(1002, fields);
+            span.log(1003, "event name");
+            span.finish(2000);
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        // Check that the Span looks right.
+        assertEquals(1, finishedSpans.size());
+        MockSpan finishedSpan = finishedSpans.get(0);
+        assertEquals("tester", finishedSpan.operationName());
+        assertEquals(0, finishedSpan.parentId());
+        assertNotEquals(0, finishedSpan.context().traceId());
+        assertNotEquals(0, finishedSpan.context().spanId());
+        assertEquals(1000, finishedSpan.startMicros());
+        assertEquals(2000, finishedSpan.finishMicros());
+        Map<String, Object> tags = finishedSpan.tags();
+        assertEquals(2, tags.size());
+        assertEquals(7, tags.get("int"));
+        assertEquals("foo", tags.get("string"));
+        List<MockSpan.LogEntry> logs = finishedSpan.logEntries();
+        assertEquals(3, logs.size());
+        {
+            MockSpan.LogEntry log = logs.get(0);
+            assertEquals(1, log.fields().size());
+            assertEquals("foo", log.fields().get("event"));
+        }
+        {
+            MockSpan.LogEntry log = logs.get(1);
+            assertEquals(1002, log.timestampMicros());
+            assertEquals(4, log.fields().get("f1"));
+            assertEquals("two", log.fields().get("f2"));
+        }
+        {
+            MockSpan.LogEntry log = logs.get(2);
+            assertEquals(1003, log.timestampMicros());
+            assertEquals("event name", log.fields().get("event"));
+        }
+    }
+
+    @Test
+    public void testChildSpan() {
+        // Create and finish a root Span.
+        MockTracer tracer = new MockTracer();
+        {
+            Span parent = tracer.buildSpan("parent").withStartTimestamp(1000).start();
+            Span child = tracer.buildSpan("child").withStartTimestamp(1100).asChildOf(parent).start();
+            child.finish(1900);
+            parent.finish(2000);
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        // Check that the Spans look right.
+        assertEquals(2, finishedSpans.size());
+        MockSpan child = finishedSpans.get(0);
+        MockSpan parent = finishedSpans.get(1);
+        assertEquals("child", child.operationName());
+        assertEquals("parent", parent.operationName());
+        assertEquals(parent.context().spanId(), child.parentId());
+        assertEquals(parent.context().traceId(), child.context().traceId());
+
+    }
+
+    @Test
+    public void testStartTimestamp() throws InterruptedException {
+        MockTracer tracer = new MockTracer();
+        long startMicros;
+        {
+            Tracer.SpanBuilder fooSpan = tracer.buildSpan("foo");
+            Thread.sleep(2);
+            startMicros = System.currentTimeMillis() * 1000;
+            fooSpan.start().finish();
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        Assert.assertEquals(1, finishedSpans.size());
+        MockSpan span = finishedSpans.get(0);
+        Assert.assertTrue(startMicros <= span.startMicros());
+        Assert.assertTrue(System.currentTimeMillis() * 1000 >= span.finishMicros());
+    }
+
+    @Test
+    public void testStartExplicitTimestamp() throws InterruptedException {
+        MockTracer tracer = new MockTracer();
+        long startMicros = 2000;
+        {
+            tracer.buildSpan("foo")
+                    .withStartTimestamp(startMicros)
+                    .start()
+                    .finish();
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        Assert.assertEquals(1, finishedSpans.size());
+        Assert.assertEquals(startMicros, finishedSpans.get(0).startMicros());
+    }
+
+    @Test
+    public void testTextMapPropagatorTextMap() {
+        MockTracer tracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
+        HashMap<String, String> injectMap = new HashMap<>();
+        injectMap.put("foobag", "donttouch");
+        {
+            Span parentSpan = tracer.buildSpan("foo")
+                    .start();
+            parentSpan.setBaggageItem("foobag", "fooitem");
+            parentSpan.finish();
+
+            tracer.inject(parentSpan.context(), Format.Builtin.TEXT_MAP,
+                    new TextMapInjectAdapter(injectMap));
+
+            SpanContext extract = tracer.extract(Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(injectMap));
+
+            Span childSpan = tracer.buildSpan("bar")
+                    .asChildOf(extract)
+                    .start();
+            childSpan.setBaggageItem("barbag", "baritem");
+            childSpan.finish();
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        Assert.assertEquals(2, finishedSpans.size());
+        Assert.assertEquals(finishedSpans.get(0).context().traceId(), finishedSpans.get(1).context().traceId());
+        Assert.assertEquals(finishedSpans.get(0).context().spanId(), finishedSpans.get(1).parentId());
+        Assert.assertEquals("fooitem", finishedSpans.get(0).getBaggageItem("foobag"));
+        Assert.assertNull(finishedSpans.get(0).getBaggageItem("barbag"));
+        Assert.assertEquals("fooitem", finishedSpans.get(1).getBaggageItem("foobag"));
+        Assert.assertEquals("baritem", finishedSpans.get(1).getBaggageItem("barbag"));
+        Assert.assertEquals("donttouch", injectMap.get("foobag"));
+    }
+
+    @Test
+    public void testTextMapPropagatorHttpHeaders() {
+        MockTracer tracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
+        {
+            Span parentSpan = tracer.buildSpan("foo")
+                    .start();
+            parentSpan.finish();
+
+            HashMap<String, String> injectMap = new HashMap<>();
+            tracer.inject(parentSpan.context(), Format.Builtin.HTTP_HEADERS,
+                    new TextMapInjectAdapter(injectMap));
+
+            SpanContext extract = tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapExtractAdapter(injectMap));
+
+            tracer.buildSpan("bar")
+                    .asChildOf(extract)
+                    .start()
+                    .finish();
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        Assert.assertEquals(2, finishedSpans.size());
+        Assert.assertEquals(finishedSpans.get(0).context().traceId(), finishedSpans.get(1).context().traceId());
+        Assert.assertEquals(finishedSpans.get(0).context().spanId(), finishedSpans.get(1).parentId());
+    }
+
+    @Test
+    public void testReset() {
+        MockTracer mockTracer = new MockTracer();
+
+        mockTracer.buildSpan("foo")
+            .startManual()
+            .finish();
+
+        assertEquals(1, mockTracer.finishedSpans().size());
+        mockTracer.reset();
+        assertEquals(0, mockTracer.finishedSpans().size());
+    }
+}

--- a/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopActiveSpanSource.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopActiveSpanSource.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.noop.v_030;
+
+import io.opentracing.SpanContext;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.ActiveSpanSource;
+import io.opentracing.v_030.Span;
+
+import java.util.Map;
+
+public interface NoopActiveSpanSource extends ActiveSpanSource {
+    NoopActiveSpanSource INSTANCE = new NoopActiveSpanSourceImpl();
+
+    interface NoopActiveSpan extends ActiveSpan {
+        NoopActiveSpanSource.NoopActiveSpan INSTANCE = new NoopActiveSpanSourceImpl.NoopActiveSpanImpl();
+    }
+    interface NoopContinuation extends ActiveSpan.Continuation {
+        NoopActiveSpanSource.NoopContinuation INSTANCE = new NoopActiveSpanSourceImpl.NoopContinuationImpl();
+    }
+}
+
+/**
+ * A noop (i.e., cheap-as-possible) implementation of an ActiveSpanSource.
+ */
+class NoopActiveSpanSourceImpl implements NoopActiveSpanSource {
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+    }
+
+    @Override
+    public ActiveSpan activeSpan() { return null; }
+
+    static class NoopActiveSpanImpl implements NoopActiveSpanSource.NoopActiveSpan {
+        @Override
+        public void deactivate() {}
+
+        @Override
+        public Continuation capture() {
+            return NoopActiveSpanSource.NoopContinuation.INSTANCE;
+        }
+
+        @Override
+        public SpanContext context() {
+            return NoopSpanContextImpl.INSTANCE;
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public NoopActiveSpan setTag(String key, String value) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan setTag(String key, boolean value) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan setTag(String key, Number value) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan log(Map<String, ?> fields) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan log(long timestampMicroseconds, Map<String, ?> fields) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan log(String event) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan log(long timestampMicroseconds, String event) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan setBaggageItem(String key, String value) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public String getBaggageItem(String key) {
+            return null;
+        }
+
+        @Override
+        public NoopActiveSpan setOperationName(String operationName) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+    }
+
+    static class NoopContinuationImpl implements NoopActiveSpanSource.NoopContinuation {
+        @Override
+        public ActiveSpan activate() {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+    }
+}

--- a/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopActiveSpanSource.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopActiveSpanSource.java
@@ -13,10 +13,10 @@
  */
 package io.opentracing.noop.v_030;
 
-import io.opentracing.SpanContext;
 import io.opentracing.v_030.ActiveSpan;
 import io.opentracing.v_030.ActiveSpanSource;
 import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
 
 import java.util.Map;
 

--- a/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopSpan.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.noop.v_030;
+
+import io.opentracing.SpanContext;
+import io.opentracing.v_030.Span;
+
+import java.util.Map;
+
+public interface NoopSpan extends Span {
+    static final NoopSpan INSTANCE = new NoopSpanImpl();
+}
+
+final class NoopSpanImpl implements NoopSpan {
+
+    @Override
+    public SpanContext context() { return NoopSpanContextImpl.INSTANCE; }
+
+    @Override
+    public void finish() {}
+
+    @Override
+    public void finish(long finishMicros) {}
+
+    @Override
+    public NoopSpan setTag(String key, String value) { return this; }
+
+    @Override
+    public NoopSpan setTag(String key, boolean value) { return this; }
+
+    @Override
+    public NoopSpan setTag(String key, Number value) { return this; }
+
+    @Override
+    public NoopSpan log(Map<String, ?> fields) { return this; }
+
+    @Override
+    public NoopSpan log(long timestampMicroseconds, Map<String, ?> fields) { return this; }
+
+    @Override
+    public NoopSpan log(String event) { return this; }
+
+    @Override
+    public NoopSpan log(long timestampMicroseconds, String event) { return this; }
+
+    @Override
+    public NoopSpan setBaggageItem(String key, String value) { return this; }
+
+    @Override
+    public String getBaggageItem(String key) { return null; }
+
+    @Override
+    public NoopSpan setOperationName(String operationName) { return this; }
+
+    @Override
+    public String toString() { return NoopSpan.class.getSimpleName(); }
+}
+

--- a/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopSpan.java
@@ -13,8 +13,8 @@
  */
 package io.opentracing.noop.v_030;
 
-import io.opentracing.SpanContext;
 import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
 
 import java.util.Map;
 

--- a/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopSpanBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.noop.v_030;
+
+import io.opentracing.SpanContext;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.BaseSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.Tracer;
+
+import java.util.Collections;
+import java.util.Map;
+
+public interface NoopSpanBuilder extends Tracer.SpanBuilder, NoopSpanContext {
+    static final NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
+}
+
+final class NoopSpanBuilderImpl implements NoopSpanBuilder {
+
+    @Override
+    public Tracer.SpanBuilder addReference(String refType, SpanContext referenced) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder asChildOf(SpanContext parent) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder ignoreActiveSpan() { return this; }
+
+    @Override
+    public Tracer.SpanBuilder asChildOf(BaseSpan parent) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, String value) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, boolean value) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, Number value) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withStartTimestamp(long microseconds) {
+        return this;
+    }
+
+    @Override
+    public Span start() {
+        return startManual();
+    }
+
+    @Override
+    public ActiveSpan startActive() {
+        return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+    }
+
+    @Override
+    public Span startManual() {
+        return NoopSpanImpl.INSTANCE;
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> baggageItems() {
+        return Collections.EMPTY_MAP.entrySet();
+    }
+
+    @Override
+    public String toString() { return NoopSpanBuilder.class.getSimpleName(); }
+}

--- a/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopSpanBuilder.java
@@ -13,10 +13,10 @@
  */
 package io.opentracing.noop.v_030;
 
-import io.opentracing.SpanContext;
 import io.opentracing.v_030.ActiveSpan;
 import io.opentracing.v_030.BaseSpan;
 import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
 import io.opentracing.v_030.Tracer;
 
 import java.util.Collections;

--- a/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopSpanContext.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopSpanContext.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.noop.v_030;
+
+import io.opentracing.SpanContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+
+public interface NoopSpanContext extends SpanContext {
+}
+
+final class NoopSpanContextImpl implements NoopSpanContext {
+    static final NoopSpanContextImpl INSTANCE = new NoopSpanContextImpl();
+
+    @Override
+    public Iterable<Map.Entry<String, String>> baggageItems() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String toString() { return NoopSpanContext.class.getSimpleName(); }
+
+}

--- a/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopTracer.java
@@ -13,10 +13,10 @@
  */
 package io.opentracing.noop.v_030;
 
-import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.v_030.ActiveSpan;
 import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
 import io.opentracing.v_030.Tracer;
 
 public interface NoopTracer extends Tracer {

--- a/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopTracer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.noop.v_030;
+
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.Tracer;
+
+public interface NoopTracer extends Tracer {
+}
+
+final class NoopTracerImpl implements NoopTracer {
+    final static NoopTracer INSTANCE = new NoopTracerImpl();
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) { return NoopSpanBuilderImpl.INSTANCE; }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {}
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) { return NoopSpanBuilderImpl.INSTANCE; }
+
+    @Override
+    public String toString() { return NoopTracer.class.getSimpleName(); }
+
+    @Override
+    public ActiveSpan activeSpan() {
+        return null;
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+    }
+}
+

--- a/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopTracerFactory.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/v_030/NoopTracerFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.noop.v_030;
+
+public final class NoopTracerFactory {
+    
+    public static NoopTracer create() {
+        return NoopTracerImpl.INSTANCE;
+    }
+
+    private NoopTracerFactory() {}
+}
+

--- a/opentracing-util/src/main/java/io/opentracing/util/v_030/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/v_030/GlobalTracer.java
@@ -13,10 +13,10 @@
  */
 package io.opentracing.util.v_030;
 
-import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.v_030.ActiveSpan;
 import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
 import io.opentracing.v_030.Tracer;
 import io.opentracing.noop.v_030.NoopTracer;
 import io.opentracing.noop.v_030.NoopTracerFactory;

--- a/opentracing-util/src/main/java/io/opentracing/util/v_030/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/v_030/GlobalTracer.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util.v_030;
+
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.noop.v_030.NoopTracer;
+import io.opentracing.noop.v_030.NoopTracerFactory;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Global tracer that forwards all methods to another tracer that can be
+ * configured by calling {@link #register(Tracer)}.
+ *
+ * <p>
+ * The {@linkplain #register(Tracer) register} method should only be called once
+ * during the application initialization phase.<br>
+ * If the {@linkplain #register(Tracer) register} method is never called,
+ * the default {@link NoopTracer} is used.
+ *
+ * <p>
+ * Where possible, use some form of dependency injection (of which there are
+ * many) to access the `Tracer` instance. For vanilla application code, this is
+ * often reasonable and cleaner for all of the usual DI reasons.
+ *
+ * <p>
+ * That said, instrumentation for packages that are themselves statically
+ * configured (e.g., JDBC drivers) may be unable to make use of said DI
+ * mechanisms for {@link Tracer} access, and as such they should fall back on
+ * {@link GlobalTracer}. By and large, OpenTracing instrumentation should
+ * always allow the programmer to specify a {@link Tracer} instance to use for
+ * instrumentation, though the {@link GlobalTracer} is a reasonable fallback or
+ * default value.
+ */
+public final class GlobalTracer implements Tracer {
+    private static final Logger LOGGER = Logger.getLogger(GlobalTracer.class.getName());
+
+    /**
+     * Singleton instance.
+     * <p>
+     * Since we cannot prevent people using {@linkplain #get() GlobalTracer.get()} as a constant,
+     * this guarantees that references obtained before, during or after initialization
+     * all behave as if obtained <em>after</em> initialization once properly initialized.<br>
+     * As a minor additional benefit it makes it harder to circumvent the {@link Tracer} API.
+     */
+    private static final GlobalTracer INSTANCE = new GlobalTracer();
+
+    /**
+     * The registered {@link Tracer} delegate or the {@link NoopTracer} if none was registered yet.
+     * Never {@code null}.
+     */
+    private static volatile Tracer tracer = NoopTracerFactory.create();
+
+    private GlobalTracer() {
+    }
+
+    /**
+     * Returns the constant {@linkplain GlobalTracer}.
+     * <p>
+     * All methods are forwarded to the currently configured tracer.<br>
+     * Until a tracer is {@link #register(Tracer) explicitly configured},
+     * the {@link io.opentracing.noop.NoopTracer NoopTracer} is used.
+     *
+     * @return The global tracer constant.
+     * @see #register(Tracer)
+     */
+    public static Tracer get() {
+        return INSTANCE;
+    }
+
+    /**
+     * Register a {@link Tracer} to back the behaviour of the {@link #get() global tracer}.
+     * <p>
+     * Registration is a one-time operation, attempting to call it more often will result in a runtime exception.
+     * <p>
+     * Every application intending to use the global tracer is responsible for registering it once
+     * during its initialization.
+     *
+     * @param tracer Tracer to use as global tracer.
+     * @throws RuntimeException if there is already a current tracer registered
+     */
+    public static synchronized void register(final Tracer tracer) {
+        if (tracer == null) {
+            throw new NullPointerException("Cannot register GlobalTracer <null>.");
+        }
+        if (tracer instanceof GlobalTracer) {
+            LOGGER.log(Level.FINE, "Attempted to register the GlobalTracer as delegate of itself.");
+            return; // no-op
+        }
+        if (isRegistered() && !GlobalTracer.tracer.equals(tracer)) {
+            throw new IllegalStateException("There is already a current global Tracer registered.");
+        }
+        GlobalTracer.tracer = tracer;
+    }
+
+    /**
+     * Identify whether a {@link Tracer} has previously been registered.
+     * <p>
+     * This check is useful in scenarios where more than one component may be responsible
+     * for registering a tracer. For example, when using a Java Agent, it will need to determine
+     * if the application has already registered a tracer, and if not attempt to resolve and
+     * register one itself.
+     *
+     * @return Whether a tracer has been registered
+     */
+    public static synchronized boolean isRegistered() {
+        return !(GlobalTracer.tracer instanceof NoopTracer);
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) {
+        return tracer.buildSpan(operationName);
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+        tracer.inject(spanContext, format, carrier);
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        return tracer.extract(format, carrier);
+    }
+
+    @Override
+    public String toString() {
+        return GlobalTracer.class.getSimpleName() + '{' + tracer + '}';
+    }
+
+    @Override
+    public ActiveSpan activeSpan() {
+        return tracer.activeSpan();
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        return tracer.makeActive(span);
+    }
+}

--- a/opentracing-util/src/main/java/io/opentracing/util/v_030/ThreadLocalActiveSpan.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/v_030/ThreadLocalActiveSpan.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util.v_030;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.opentracing.SpanContext;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.ActiveSpanSource;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.Tracer;
+
+/**
+ * {@link ThreadLocalActiveSpan} is a simple {@link ActiveSpan} implementation that relies on Java's
+ * thread-local storage primitive.
+ *
+ * @see ActiveSpanSource
+ * @see Tracer#activeSpan()
+ */
+public class ThreadLocalActiveSpan implements ActiveSpan {
+    private final ThreadLocalActiveSpanSource source;
+    private final Span wrapped;
+    private final ThreadLocalActiveSpan toRestore;
+    private final AtomicInteger refCount;
+
+    ThreadLocalActiveSpan(ThreadLocalActiveSpanSource source, Span wrapped, AtomicInteger refCount) {
+        this.source = source;
+        this.refCount = refCount;
+        this.wrapped = wrapped;
+        this.toRestore = source.tlsSnapshot.get();
+        source.tlsSnapshot.set(this);
+    }
+
+    @Override
+    public void deactivate() {
+        if (source.tlsSnapshot.get() != this) {
+            // This shouldn't happen if users call methods in the expected order. Bail out.
+            return;
+        }
+        source.tlsSnapshot.set(toRestore);
+
+        if (0 == refCount.decrementAndGet()) {
+            wrapped.finish();
+        }
+    }
+
+    @Override
+    public Continuation capture() {
+        return new ThreadLocalActiveSpan.Continuation();
+    }
+
+    @Override
+    public SpanContext context() {
+        return wrapped.context();
+    }
+
+    @Override
+    public ThreadLocalActiveSpan setTag(String key, String value) {
+        wrapped.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan setTag(String key, boolean value) {
+        wrapped.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan setTag(String key, Number value) {
+        wrapped.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan log(Map<String, ?> fields) {
+        wrapped.log(fields);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan log(long timestampMicroseconds, Map<String, ?> fields) {
+        wrapped.log(timestampMicroseconds, fields);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan log(String event) {
+        wrapped.log(event);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan log(long timestampMicroseconds, String event) {
+        wrapped.log(timestampMicroseconds, event);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan setBaggageItem(String key, String value) {
+        wrapped.setBaggageItem(key, value);
+        return this;
+    }
+
+    @Override
+    public String getBaggageItem(String key) {
+        return wrapped.getBaggageItem(key);
+    }
+
+    @Override
+    public ThreadLocalActiveSpan setOperationName(String operationName) {
+        wrapped.setOperationName(operationName);
+        return this;
+    }
+
+    @Override
+    public void close() {
+        deactivate();
+    }
+
+    @Override
+    public String toString() {
+        return wrapped.toString();
+    }
+
+    private final class Continuation implements ActiveSpan.Continuation {
+        Continuation() {
+            refCount.incrementAndGet();
+        }
+
+        @Override
+        public ThreadLocalActiveSpan activate() {
+            return new ThreadLocalActiveSpan(source, wrapped, refCount);
+        }
+    }
+
+}

--- a/opentracing-util/src/main/java/io/opentracing/util/v_030/ThreadLocalActiveSpan.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/v_030/ThreadLocalActiveSpan.java
@@ -16,10 +16,10 @@ package io.opentracing.util.v_030;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.opentracing.SpanContext;
 import io.opentracing.v_030.ActiveSpan;
 import io.opentracing.v_030.ActiveSpanSource;
 import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
 import io.opentracing.v_030.Tracer;
 
 /**

--- a/opentracing-util/src/main/java/io/opentracing/util/v_030/ThreadLocalActiveSpanSource.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/v_030/ThreadLocalActiveSpanSource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util.v_030;
+
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.ActiveSpanSource;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.Tracer;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A simple {@link ActiveSpanSource} implementation built on top of Java's thread-local storage primitive.
+ *
+ * @see ThreadLocalActiveSpan
+ * @see Tracer#activeSpan()
+ */
+public class ThreadLocalActiveSpanSource implements ActiveSpanSource {
+    final ThreadLocal<ThreadLocalActiveSpan> tlsSnapshot = new ThreadLocal<ThreadLocalActiveSpan>();
+
+    @Override
+    public ThreadLocalActiveSpan activeSpan() {
+        return tlsSnapshot.get();
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        return new ThreadLocalActiveSpan(this, span, new AtomicInteger(1));
+    }
+
+}

--- a/opentracing-util/src/test/java/io/opentracing/util/v_030/GlobalTracerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/v_030/GlobalTracerTest.java
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
+import io.opentracing.v_030.SpanContext;
 import io.opentracing.v_030.Tracer;
 import io.opentracing.noop.v_030.NoopSpanBuilder;
 import io.opentracing.noop.v_030.NoopTracerFactory;

--- a/opentracing-util/src/test/java/io/opentracing/util/v_030/GlobalTracerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/v_030/GlobalTracerTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util.v_030;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.noop.v_030.NoopSpanBuilder;
+import io.opentracing.noop.v_030.NoopTracerFactory;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GlobalTracerTest {
+
+    private static void _setGlobal(Tracer tracer) {
+        try {
+            Field globalTracerField = GlobalTracer.class.getDeclaredField("tracer");
+            globalTracerField.setAccessible(true);
+            globalTracerField.set(null, tracer);
+            globalTracerField.setAccessible(false);
+        } catch (Exception e) {
+            throw new RuntimeException("Error reflecting globalTracer: " + e.getMessage(), e);
+        }
+    }
+
+    @Before
+    @After
+    public void clearGlobalTracer() {
+        _setGlobal(NoopTracerFactory.create());
+    }
+
+    @Test
+    public void testGet_SingletonReference() {
+        Tracer tracer = GlobalTracer.get();
+        assertThat(tracer, is(instanceOf(GlobalTracer.class)));
+        assertThat(tracer, is(sameInstance(GlobalTracer.get())));
+    }
+
+    @Test
+    public void testMultipleRegistrations() {
+        GlobalTracer.register(mock(Tracer.class));
+        try {
+            GlobalTracer.register(mock(Tracer.class));
+            fail("Duplicate registration exception expected.");
+        } catch (RuntimeException expected) {
+            assertThat("Duplicate registration message", expected.getMessage(), is(notNullValue()));
+        }
+    }
+
+    /**
+     * Check leniency for duplicate registration with the same tracer by mistake.
+     */
+    @Test
+    public void testMultipleRegistrations_sameTracer() {
+        Tracer mockTracer = mock(Tracer.class);
+        GlobalTracer.register(mockTracer);
+        GlobalTracer.register(mockTracer);
+        // 'test' that double registration of the same tracer does not throw exception
+    }
+
+    @Test
+    public void testRegisterGlobalTracer() {
+        assertThat(GlobalTracer.get().buildSpan("foo"), is(instanceOf(NoopSpanBuilder.class)));
+        GlobalTracer.register(GlobalTracer.get());
+        assertThat(GlobalTracer.get().buildSpan("foo"), is(instanceOf(NoopSpanBuilder.class)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testRegisterNull() {
+        GlobalTracer.register(null);
+    }
+
+    @Test
+    public void testNoopTracerByDefault() {
+        Tracer.SpanBuilder spanBuilder = GlobalTracer.get().buildSpan("my-operation");
+        assertThat(spanBuilder, is(instanceOf(NoopSpanBuilder.class)));
+    }
+
+    @Test
+    public void testDelegation_buildSpan() {
+        Tracer mockTracer = mock(Tracer.class);
+        GlobalTracer.register(mockTracer);
+        GlobalTracer.get().buildSpan("my-operation");
+
+        verify(mockTracer).buildSpan(eq("my-operation"));
+        verifyNoMoreInteractions(mockTracer);
+    }
+
+    @Test
+    public void testDelegation_inject() {
+        Tracer mockTracer = mock(Tracer.class);
+        SpanContext mockContext = mock(SpanContext.class);
+        Format<Object> mockFormat = mock(Format.class);
+        Object mockCarrier = mock(Object.class);
+        GlobalTracer.register(mockTracer);
+        GlobalTracer.get().inject(mockContext, mockFormat, mockCarrier);
+
+        verify(mockTracer).inject(eq(mockContext), eq(mockFormat), eq(mockCarrier));
+        verifyNoMoreInteractions(mockTracer, mockContext, mockFormat, mockCarrier);
+    }
+
+    @Test
+    public void testDelegation_extract() {
+        Tracer mockTracer = mock(Tracer.class);
+        Format<Object> mockFormat = mock(Format.class);
+        Object mockCarrier = mock(Object.class);
+        GlobalTracer.register(mockTracer);
+        GlobalTracer.get().extract(mockFormat, mockCarrier);
+
+        verify(mockTracer).extract(eq(mockFormat), eq(mockCarrier));
+        verifyNoMoreInteractions(mockTracer, mockFormat, mockCarrier);
+    }
+
+    @Test
+    public void concurrencyTest() throws InterruptedException, ExecutionException {
+        final int threadCount = 10;
+        ExecutorService threadpool = Executors.newFixedThreadPool(2 * threadCount);
+        try {
+            // Try to do ten register() calls and ten buildSpan() calls concurrently.
+            List<Callable<Void>> registerCalls = new ArrayList<Callable<Void>>();
+            List<Callable<Tracer.SpanBuilder>> buildSpanCalls = new ArrayList<Callable<Tracer.SpanBuilder>>();
+            for (int i = 0; i < threadCount; i++) {
+                registerCalls.add(new Callable<Void>() {
+                    @Override
+                    public Void call() throws Exception {
+                        GlobalTracer.register(mock(Tracer.class));
+                        return null;
+                    }
+                });
+                buildSpanCalls.add(new Callable<Tracer.SpanBuilder>() {
+                    @Override
+                    public Tracer.SpanBuilder call() throws Exception {
+                        return GlobalTracer.get().buildSpan("my-operation");
+                    }
+                });
+            }
+
+            // Schedule the threads.
+            List<Future<Void>> registerResults = threadpool.invokeAll(registerCalls);
+            List<Future<Tracer.SpanBuilder>> buildSpanResults = threadpool.invokeAll(buildSpanCalls);
+
+            boolean registered = false; // there may only be one registration success.
+            int exceptions = 0;
+            for (Future<Void> result : registerResults) {
+                try {
+                    result.get(); // void, but should throw exception 9 times
+                    assertThat("previous registration", registered, is(false));
+                    registered = true;
+                } catch (ExecutionException expected) {
+                    exceptions++;
+                }
+            }
+            assertThat("Tracer registration", registered, is(true));
+            assertThat("Registration exceptions", exceptions, is(threadCount - 1));
+
+            for (Future<Tracer.SpanBuilder> result : buildSpanResults) {
+                // each spanbuilder must be either null (from registered mock tracer) or noop
+                assertThat("SpanBuilder", result.get(), anyOf(nullValue(), instanceOf(NoopSpanBuilder.class)));
+            }
+
+        } finally {
+            threadpool.shutdown();
+        }
+    }
+
+    @Test
+    public void testIsRegistered() {
+        assertThat("Should not be registered", GlobalTracer.isRegistered(), is(false));
+        GlobalTracer.register(mock(Tracer.class));
+        assertThat("Should be registered", GlobalTracer.isRegistered(), is(true));
+    }
+
+}

--- a/opentracing-util/src/test/java/io/opentracing/util/v_030/ThreadLocalActiveSpanSourceTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/v_030/ThreadLocalActiveSpanSourceTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util.v_030;
+
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ThreadLocalActiveSpanSourceTest {
+    private ThreadLocalActiveSpanSource source;
+    @Before
+    public void before() throws Exception {
+        source = new ThreadLocalActiveSpanSource();
+    }
+
+    @Test
+    public void missingActiveSpan() throws Exception {
+        ActiveSpan missingSpan = source.activeSpan();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void makeActiveSpan() throws Exception {
+        Span span = mock(Span.class);
+
+        // We can't use 1.7 features like try-with-resources in this repo without meddling with pom details for tests.
+        ActiveSpan activeSpan = source.makeActive(span);
+        try {
+            assertNotNull(activeSpan);
+            ActiveSpan otherActiveSpan = source.activeSpan();
+            assertEquals(otherActiveSpan, activeSpan);
+        } finally {
+            activeSpan.close();
+        }
+
+        // Make sure the Span got finish()ed.
+        verify(span).finish();
+
+        // And now it's gone:
+        ActiveSpan missingSpan = source.activeSpan();
+        assertNull(missingSpan);
+    }
+
+}

--- a/opentracing-util/src/test/java/io/opentracing/util/v_030/ThreadLocalActiveSpanTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/v_030/ThreadLocalActiveSpanTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util.v_030;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ThreadLocalActiveSpanTest {
+    private ThreadLocalActiveSpanSource source;
+
+    @Before
+    public void before() throws Exception {
+        source = new ThreadLocalActiveSpanSource();
+    }
+
+    @Test
+    public void continuation() throws Exception {
+        Span span = mock(Span.class);
+
+        // Quasi try-with-resources (this is 1.6).
+        ActiveSpan activeSpan = source.makeActive(span);
+        ActiveSpan.Continuation continued = null;
+        try {
+            assertNotNull(activeSpan);
+            continued = activeSpan.capture();
+        } finally {
+            activeSpan.close();
+        }
+
+        // Make sure the Span was not finished since there was a capture().
+        verify(span, never()).finish();
+
+        // Activate the continuation.
+        try {
+            activeSpan = continued.activate();
+        } finally {
+            activeSpan.close();
+        }
+
+        // Now the Span should be finished.
+        verify(span, times(1)).finish();
+
+        // And now it's no longer active.
+        ActiveSpan missingSpan = source.activeSpan();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void implicitSpanStack() throws Exception {
+        Span backgroundSpan = mock(Span.class);
+        Span foregroundSpan = mock(Span.class);
+
+        // Quasi try-with-resources (this is 1.6).
+        ActiveSpan backgroundActive = source.makeActive(backgroundSpan);
+        try {
+            assertNotNull(backgroundActive);
+
+            // Activate a new ActiveSpan on top of the background one.
+            ActiveSpan foregroundActive = source.makeActive(foregroundSpan);
+            try {
+                ActiveSpan shouldBeForeground = source.activeSpan();
+                assertEquals(foregroundActive, shouldBeForeground);
+            } finally {
+                foregroundActive.close();
+            }
+
+            // And now the backgroundActive should be reinstated.
+            ActiveSpan shouldBeBackground = source.activeSpan();
+            assertEquals(backgroundActive, shouldBeBackground);
+        } finally {
+            backgroundActive.close();
+        }
+
+        // The background and foreground Spans should be finished.
+        verify(backgroundSpan, times(1)).finish();
+        verify(foregroundSpan, times(1)).finish();
+
+        // And now nothing is active.
+        ActiveSpan missingSpan = source.activeSpan();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void testDeactivateWhenDifferentSpanIsActive() {
+        Span span = mock(Span.class);
+
+        ActiveSpan activeSpan = source.makeActive(span);
+        source.makeActive(mock(Span.class));
+        activeSpan.deactivate();
+
+        verify(span, times(0)).finish();
+    }
+}


### PR DESCRIPTION
In order to keep backwards compatibility with the 0.30 version, the ActiveSpan API is kept under a v_030 su package (for each one of our modules).

SpanContext, as well as propagation and tags packages are kept in place, as they did not change between 0.30 and 0.31.

For your consideration. Feedback is appreciated.