### PR TITLE
Add a 0.30 compatibility package/layer

### DIFF
--- a/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScope.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScope.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AutoFinishScope implements Scope {
+    final AutoFinishScopeManager manager;
+    final AtomicInteger refCount;
+    private final Span wrapped;
+    private final AutoFinishScope toRestore;
+
+    AutoFinishScope(AutoFinishScopeManager manager, AtomicInteger refCount, Span wrapped) {
+        this.manager = manager;
+        this.refCount = refCount;
+        this.wrapped = wrapped;
+        this.toRestore = manager.tlsScope.get();
+        manager.tlsScope.set(this);
+    }
+
+    public class Continuation {
+        public Continuation() {
+            refCount.incrementAndGet();
+        }
+
+        public AutoFinishScope activate() {
+            return new AutoFinishScope(manager, refCount, wrapped);
+        }
+    }
+
+    public Continuation capture() {
+        return new Continuation();
+    }
+
+    @Override
+    public void close() {
+        if (manager.tlsScope.get() != this) {
+            return;
+        }
+
+        if (refCount.decrementAndGet() == 0) {
+            wrapped.finish();
+        }
+
+        manager.tlsScope.set(toRestore);
+    }
+
+    @Override
+    public Span span() {
+        return wrapped;
+    }
+}

--- a/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AutoFinishScopeManager implements ScopeManager {
+    final ThreadLocal<AutoFinishScope> tlsScope = new ThreadLocal<AutoFinishScope>();
+
+    @Override
+    public AutoFinishScope activate(Span span) {
+        return new AutoFinishScope(this, new AtomicInteger(1), span);
+    }
+
+    @Override
+    public AutoFinishScope activate(Span span, boolean finishOnClose) {
+        return new AutoFinishScope(this, new AtomicInteger(1), span);
+    }
+
+    @Override
+    public AutoFinishScope active() {
+        return tlsScope.get();
+    }
+}

--- a/opentracing-util/src/test/java/io/opentracing/util/AutoFinishScopeManagerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/AutoFinishScopeManagerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class AutoFinishScopeManagerTest {
+    private AutoFinishScopeManager source;
+    @Before
+    public void before() throws Exception {
+        source = new AutoFinishScopeManager();
+    }
+
+    @Test
+    public void missingScope() throws Exception {
+        Scope missingSpan = source.active();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void activateSpan() throws Exception {
+        Span span = mock(Span.class);
+
+        // We can't use 1.7 features like try-with-resources in this repo without meddling with pom details for tests.
+        Scope active = source.activate(span);
+        try {
+            assertNotNull(active);
+            Scope otherScope = source.active();
+            assertEquals(otherScope, active);
+        } finally {
+            active.close();
+        }
+
+        // Make sure the Span got finish()ed.
+        verify(span).finish();
+
+        // And now it's gone:
+        Scope missingSpan = source.active();
+        assertNull(missingSpan);
+    }
+
+}

--- a/opentracing-util/src/test/java/io/opentracing/util/AutoFinishScopeTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/AutoFinishScopeTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AutoFinishScopeTest {
+    private AutoFinishScopeManager manager;
+
+    @Before
+    public void before() throws Exception {
+        manager = new AutoFinishScopeManager();
+    }
+
+    @Test
+    public void continuation() throws Exception {
+        Span span = mock(Span.class);
+
+        // Quasi try-with-resources (this is 1.6).
+        AutoFinishScope active = (AutoFinishScope)manager.activate(span);
+        AutoFinishScope.Continuation continued = null;
+        try {
+            assertNotNull(active);
+            continued = active.capture();
+        } finally {
+            active.close();
+        }
+
+        // Make sure the Span was not finished since there was a capture().
+        verify(span, never()).finish();
+
+        // Activate the continuation.
+        try {
+            active = continued.activate();
+        } finally {
+            active.close();
+        }
+
+        // Now the Span should be finished.
+        verify(span, times(1)).finish();
+
+        // And now it's no longer active.
+        Scope missingSpan = manager.active();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void implicitSpanStack() throws Exception {
+        Span backgroundSpan = mock(Span.class);
+        Span foregroundSpan = mock(Span.class);
+
+        // Quasi try-with-resources (this is 1.6).
+        Scope backgroundActive = manager.activate(backgroundSpan);
+        try {
+            assertNotNull(backgroundActive);
+
+            // Activate a new Scope on top of the background one.
+            Scope foregroundActive = manager.activate(foregroundSpan);
+            try {
+                Scope shouldBeForeground = manager.active();
+                assertEquals(foregroundActive, shouldBeForeground);
+            } finally {
+                foregroundActive.close();
+            }
+
+            // And now the backgroundActive should be reinstated.
+            Scope shouldBeBackground = manager.active();
+            assertEquals(backgroundActive, shouldBeBackground);
+        } finally {
+            backgroundActive.close();
+        }
+
+        // The background and foreground Spans should be finished.
+        verify(backgroundSpan, times(1)).finish();
+        verify(foregroundSpan, times(1)).finish();
+
+        // And now nothing is active.
+        Scope missingSpan = manager.active();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void testDeactivateWhenDifferentSpanIsActive() {
+        Span span = mock(Span.class);
+
+        Scope active = manager.activate(span);
+        manager.activate(mock(Span.class));
+        active.close();
+
+        verify(span, times(0)).finish();
+    }
+}

--- a/opentracing-v030/README.md
+++ b/opentracing-v030/README.md
@@ -1,0 +1,69 @@
+# OpenTracing-Java 0.30 compatibility layer.
+
+The `opentracing-v030` artifact provides a 0.30 API compatibility layer which comprises:
+1. Exposing all the the 0.30 packages under `io.opentracing.v_030` (`io.opentracing.v_030.propagation`, `io.opentracing.v_30.util`, etc).
+2. A Shim layer to wrap 0.31 Tracer and expose it under the 0.30 API.
+
+## Shim Layer
+
+The basic shim layer is exposed through `TracerShim`, which wraps a `io.opentracing.Tracer` object and exposes it under the `io.opentracing.v_030.Tracer` interface:
+
+```java
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.shim.TracerShim;
+```
+
+For `ActiveSpan.capture()` and `Continuation`s support, the usage of `io.opentracing.util.AutoFinishScopeManager` as `Tracer.scopeManager()` is required (which preserves the reference-count system used in 0.30).
+
+```java
+import io.opentracing.util.AutoFinishScopeManager;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.shim.AutoFinishTracerShim;
+
+io.opentracing.Tracer upstreamTracer = new CustomTracer(..., new AutoFinishScopeManager());
+Tracer tracer = new TracerShim(yourUpstreamTracer);
+
+try (ActiveSpan span = tracer.buildSpan("parent").startActive()) {
+    ActiveSpan.Continuation cont = span.capture();
+    ...
+}
+```
+
+## Extending the Shim layer
+
+When the Shim layer is required without the reference-count system, it's possible to provide a custom class extending `BaseTracerShim`, which will need to provide a custom `ActiveSpanShim` instance upong `Span` activation:
+
+```java
+import io.opentracing.util.AutoFinishScopeManager;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.shim.AutoFinishTracerShim;
+
+
+public class CustomTracerShim extends BaseTracerShim {
+    public CustomTracerShim(io.opentracing.Tracer tracer) {
+        super(tracer);
+    }
+
+    @Override
+    public ActiveSpanShim createActiveSpanShim(Scope scope) {
+        return CustomActiveSpanShim(scope);
+    }
+
+    static final class CustomActiveSpanShim extends ActiveSpanShim {
+        public CustomActiveSpanShim(Scope scope) {
+            super(scope);
+        }
+
+        @Override
+        public Continuation capture() {
+            ...
+        }
+    }
+}
+```
+
+The returned `ActiveSpanShim` instance must react properly to `ActiveSpan.capture()` and return a `ActiveSpan.Continuation` object than can later be reactivated. Observe the default implementation of `ActiveSpanShim.capture()` throws `UnsupportedOperationException`.
+

--- a/opentracing-v030/pom.xml
+++ b/opentracing-v030/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2017 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.opentracing</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.30.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>opentracing-v030</artifactId>
+    <name>OpenTracing-v030</name>
+    <description>OpenTracing 0.30 compatibility layer</description>
+
+    <properties>
+        <main.basedir>${project.basedir}/..</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>opentracing-util</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/ActiveSpan.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/ActiveSpan.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+import java.io.Closeable;
+
+/**
+ * {@link ActiveSpan} inherits all of the OpenTracing functionality in {@link BaseSpan} and layers on in-process
+ * propagation capabilities.
+ *
+ * <p>
+ * In any given thread there is at most one {@link ActiveSpan "active" span} primarily responsible for the work
+ * accomplished by the surrounding application code. That {@link ActiveSpan} may be accessed via the
+ * {@link ActiveSpanSource#activeSpan()} method. If the application needs to defer work that should be part of
+ * the same Span, the Source provides a {@link ActiveSpan#capture} method that returns a {@link Continuation};
+ * this continuation may be used to re-activate and continue the {@link Span} in that other asynchronous executor
+ * and/or thread.
+ *
+ * <p>
+ * {@link ActiveSpan}s are created via {@link Tracer.SpanBuilder#startActive()} or, less commonly,
+ * {@link ActiveSpanSource#makeActive}. Per the above, they can be {@link ActiveSpan#capture()}ed as
+ * {@link ActiveSpan.Continuation}s, then re-{@link Continuation#activate()}d later.
+ *
+ * <p>
+ * NOTE: {@link ActiveSpan} extends {@link Closeable} rather than {@code AutoCloseable} in order to preserve support
+ * for JDK1.6.
+ *
+ * @see Tracer.SpanBuilder#startActive()
+ * @see Continuation#activate()
+ * @see ActiveSpanSource
+ * @see BaseSpan
+ * @see Span
+ */
+public interface ActiveSpan extends Closeable, BaseSpan<ActiveSpan> {
+    /**
+     * Mark the end of the active period for the current thread and {@link ActiveSpan}. When the last
+     * {@link ActiveSpan} is deactivated for a given {@link Span}, it is automatically {@link Span#finish()}ed.
+     *
+     * <p>
+     * NOTE: Calling {@link #deactivate} more than once on a single {@link ActiveSpan} instance leads to undefined
+     * behavior.
+     *
+     * @see Closeable#close() {@link ActiveSpan}s are auto-closeable and may be used in try-with-resources blocks
+     */
+    void deactivate();
+
+    /**
+     * A synonym for {@link #deactivate()} that can be used in try-with-resources blocks.
+     */
+    @Override
+    void close();
+
+    /**
+     * "Capture" a new {@link Continuation} associated with this {@link ActiveSpan} and {@link Span}, as well as any
+     * 3rd-party execution context of interest. The {@link Continuation} may be used as data in a closure or callback
+     * function where the {@link ActiveSpan} may be resumed and reactivated.
+     *
+     * <p>
+     * <em>IMPORTANT:</em> the caller MUST {@link Continuation#activate()} and {@link ActiveSpan#deactivate()} the
+     * returned {@link Continuation} or the associated {@link Span} will never automatically {@link Span#finish()}.
+     * That is, calling {@link #capture()} increments a refcount that must be decremented somewhere else.
+     *
+     * <p>
+     * The associated {@link Span} will not {@link Span#finish()} while a {@link Continuation} is outstanding; in
+     * this way, it provides a reference/pin just like an {@link ActiveSpan} does.
+     *
+     * @return a new {@link Continuation} to {@link Continuation#activate()} at the appropriate time.
+     */
+    Continuation capture();
+
+    /**
+     * A {@link Continuation} can be used <em>once</em> to activate a Span along with any non-OpenTracing execution
+     * context (e.g., MDC), then deactivate when processing activity moves on to another Span. (In practice, this
+     * active period typically extends for the length of a deferred async closure invocation.)
+     *
+     * <p>
+     * Most users do not directly interact with {@link Continuation}, {@link Continuation#activate()} or
+     * {@link ActiveSpan#deactivate()}, but rather use {@link ActiveSpanSource}-aware Runnables/Callables/Executors.
+     * Those higher-level primitives do not <em>need</em> to be defined within the OpenTracing core API, and so
+     * they are not.
+     *
+     * @see ActiveSpanSource#makeActive(Span)
+     */
+    interface Continuation {
+        /**
+         * Make the Span (and other execution context) encapsulated by this {@link Continuation} active and
+         * return it.
+         *
+         * <p>
+         * NOTE: It is an error to call activate() more than once on a single Continuation instance.
+         *
+         * @see ActiveSpanSource#makeActive(Span)
+         * @return a handle to the newly-activated {@link ActiveSpan}
+         */
+        ActiveSpan activate();
+    }
+
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/ActiveSpanSource.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/ActiveSpanSource.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+/**
+ * {@link ActiveSpanSource} allows an existing (possibly thread-local-aware) execution context provider to act as a
+ * source for an actively-scheduled OpenTracing Span.
+ *
+ * <p>
+ * {@link ActiveSpanSource} is a super-interface to {@link Tracer}, so note that all {@link Tracer}s fulfill the
+ * {@link ActiveSpanSource} contract.
+ *
+ * @see ActiveSpan
+ */
+public interface ActiveSpanSource {
+
+    /**
+     * Return the {@link ActiveSpan active span}. This does not affect the internal reference count for the
+     * {@link ActiveSpan}.
+     *
+     * <p>
+     * If there is an {@link ActiveSpan active span}, it becomes an implicit parent of any newly-created
+     * {@link BaseSpan span} at {@link Tracer.SpanBuilder#startActive()} time (rather than at
+     * {@link Tracer#buildSpan(String)} time).
+     *
+     * @return the {@link ActiveSpan active span}, or null if none could be found.
+     */
+    ActiveSpan activeSpan();
+
+    /**
+     * Wrap and "make active" a {@link Span} by encapsulating it – and any active state (e.g., MDC state) in the
+     * current thread – in a new {@link ActiveSpan}.
+     *
+     * @param span the Span to wrap in an {@link ActiveSpan}
+     * @return an {@link ActiveSpan} that encapsulates the given {@link Span} and any other
+     *     {@link ActiveSpanSource}-specific context (e.g., the MDC context map)
+     */
+    ActiveSpan makeActive(Span span);
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/BaseSpan.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/BaseSpan.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+import java.util.Map;
+
+/**
+ * {@link BaseSpan} represents the OpenTracing specification's span contract with the exception of methods to finish
+ * said span. For those, either use {@link Span#finish()} or {@link ActiveSpan#deactivate()} depending on the
+ * programming model.
+ *
+ * @see Span
+ * @see ActiveSpan
+ * @see Tracer.SpanBuilder#startManual()
+ * @see Tracer.SpanBuilder#startActive()
+ */
+public interface BaseSpan<S extends BaseSpan> {
+    /**
+     * Retrieve the associated SpanContext.
+     *
+     * This may be called at any time, including after calls to finish().
+     *
+     * @return the SpanContext that encapsulates Span state that should propagate across process boundaries.
+     */
+    SpanContext context();
+
+    /**
+     * Set a key:value tag on the Span.
+     */
+    S setTag(String key, String value);
+
+    /** Same as {@link #setTag(String, String)}, but for boolean values. */
+    S setTag(String key, boolean value);
+
+    /** Same as {@link #setTag(String, String)}, but for numeric values. */
+    S setTag(String key, Number value);
+
+    /**
+     * Log key:value pairs to the Span with the current walltime timestamp.
+     *
+     * <p><strong>CAUTIONARY NOTE:</strong> not all Tracer implementations support key:value log fields end-to-end.
+     * Caveat emptor.
+     *
+     * <p>A contrived example (using Guava, which is not required):
+     * <pre><code>
+     span.log(
+     ImmutableMap.Builder<String, Object>()
+     .put("event", "soft error")
+     .put("type", "cache timeout")
+     .put("waited.millis", 1500)
+     .build());
+     </code></pre>
+     *
+     * @param fields key:value log fields. Tracer implementations should support String, numeric, and boolean values;
+     *               some may also support arbitrary Objects.
+     * @return the Span, for chaining
+     * @see Span#log(String)
+     */
+    S log(Map<String, ?> fields);
+
+    /**
+     * Like log(Map&lt;String, Object&gt;), but with an explicit timestamp.
+     *
+     * <p><strong>CAUTIONARY NOTE:</strong> not all Tracer implementations support key:value log fields end-to-end.
+     * Caveat emptor.
+     *
+     * @param timestampMicroseconds The explicit timestamp for the log record. Must be greater than or equal to the
+     *                              Span's start timestamp.
+     * @param fields key:value log fields. Tracer implementations should support String, numeric, and boolean values;
+     *               some may also support arbitrary Objects.
+     * @return the Span, for chaining
+     * @see Span#log(long, String)
+     */
+    S log(long timestampMicroseconds, Map<String, ?> fields);
+
+    /**
+     * Record an event at the current walltime timestamp.
+     *
+     * Shorthand for
+     *
+     * <pre><code>
+     span.log(Collections.singletonMap("event", event));
+     </code></pre>
+     *
+     * @param event the event value; often a stable identifier for a moment in the Span lifecycle
+     * @return the Span, for chaining
+     */
+    S log(String event);
+
+    /**
+     * Record an event at a specific timestamp.
+     *
+     * Shorthand for
+     *
+     * <pre><code>
+     span.log(timestampMicroseconds, Collections.singletonMap("event", event));
+     </code></pre>
+     *
+     * @param timestampMicroseconds The explicit timestamp for the log record. Must be greater than or equal to the
+     *                              Span's start timestamp.
+     * @param event the event value; often a stable identifier for a moment in the Span lifecycle
+     * @return the Span, for chaining
+     */
+    S log(long timestampMicroseconds, String event);
+
+    /**
+     * Sets a baggage item in the Span (and its SpanContext) as a key/value pair.
+     *
+     * Baggage enables powerful distributed context propagation functionality where arbitrary application data can be
+     * carried along the full path of request execution throughout the system.
+     *
+     * Note 1: Baggage is only propagated to the future (recursive) children of this SpanContext.
+     *
+     * Note 2: Baggage is sent in-band with every subsequent local and remote calls, so this feature must be used with
+     * care.
+     *
+     * @return this Span instance, for chaining
+     */
+    S setBaggageItem(String key, String value);
+
+    /**
+     * @return the value of the baggage item identified by the given key, or null if no such item could be found
+     */
+    String getBaggageItem(String key);
+
+    /**
+     * Sets the string name for the logical operation this span represents.
+     *
+     * @return this Span instance, for chaining
+     */
+    S setOperationName(String operationName);
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/References.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/References.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+/**
+ * References is essentially a namespace for the official OpenTracing reference types.
+ *
+ * References are used by Tracer.buildSpan() to describe the relationships between Spans.
+ *
+ * @see Tracer.SpanBuilder#addReference(String, SpanContext)
+ */
+public final class References {
+    private References(){}
+
+    /**
+     * See http://opentracing.io/spec/#causal-span-references for more information about CHILD_OF references
+     */
+    public static final String CHILD_OF = "child_of";
+
+    /**
+     * See http://opentracing.io/spec/#causal-span-references for more information about FOLLOWS_FROM references
+     */
+    public static final String FOLLOWS_FROM = "follows_from";
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/Span.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/Span.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+/**
+ * Represents an in-flight Span that's <strong>manually propagated</strong> within the given process. Most of
+ * the API lives in {@link BaseSpan}.
+ *
+ * <p>{@link Span}s are created by the {@link Tracer.SpanBuilder#startManual} method; see {@link ActiveSpan} for
+ * a {@link BaseSpan} extension designed for automatic in-process propagation.
+ *
+ * @see ActiveSpan for automatic propagation (recommended for most intstrumentation!)
+ */
+public interface Span extends BaseSpan<Span> {
+    /**
+     * Sets the end timestamp to now and records the span.
+     *
+     * <p>With the exception of calls to {@link #context}, this should be the last call made to the span instance.
+     * Future calls to {@link #finish} are defined as noops, and future calls to methods other than {@link #context}
+     * lead to undefined behavior.
+     *
+     * @see Span#context()
+     */
+    void finish();
+
+    /**
+     * Sets an explicit end timestamp and records the span.
+     *
+     * <p>With the exception of calls to Span.context(), this should be the last call made to the span instance, and to
+     * do otherwise leads to undefined behavior.
+     *
+     * @param finishMicros an explicit finish time, in microseconds since the epoch
+     *
+     * @see Span#context()
+     */
+    void finish(long finishMicros);
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/SpanContext.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/SpanContext.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+import java.util.Map;
+
+/**
+ * SpanContext represents Span state that must propagate to descendant Spans and across process boundaries.
+ *
+ * SpanContext is logically divided into two pieces: (1) the user-level "Baggage" that propagates across Span
+ * boundaries and (2) any Tracer-implementation-specific fields that are needed to identify or otherwise contextualize
+ * the associated Span instance (e.g., a &lt;trace_id, span_id, sampled&gt; tuple).
+ *
+ * @see Span#setBaggageItem(String, String)
+ * @see Span#getBaggageItem(String)
+ */
+public interface SpanContext {
+    /**
+     * @return all zero or more baggage items propagating along with the associated Span
+     *
+     * @see Span#setBaggageItem(String, String)
+     * @see Span#getBaggageItem(String)
+     */
+    Iterable<Map.Entry<String, String>> baggageItems();
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/Tracer.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/Tracer.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+import io.opentracing.v_030.propagation.Format;
+
+/**
+ * Tracer is a simple, thin interface for Span creation and propagation across arbitrary transports.
+ */
+public interface Tracer extends ActiveSpanSource {
+
+    /**
+     * Return a new SpanBuilder for a Span with the given `operationName`.
+     *
+     * <p>You can override the operationName later via {@link Span#setOperationName(String)}.
+     *
+     * <p>A contrived example:
+     * <pre><code>
+     *   Tracer tracer = ...
+     *
+     *   // Note: if there is a `tracer.activeSpan()`, it will be used as the target of an implicit CHILD_OF
+     *   // Reference for "workSpan" when `startActive()` is invoked.
+     *   try (ActiveSpan workSpan = tracer.buildSpan("DoWork").startActive()) {
+     *       workSpan.setTag("...", "...");
+     *       // etc, etc
+     *   }
+     *
+     *   // It's also possible to create Spans manually, bypassing the ActiveSpanSource activation.
+     *   Span http = tracer.buildSpan("HandleHTTPRequest")
+     *                     .asChildOf(rpcSpanContext)  // an explicit parent
+     *                     .withTag("user_agent", req.UserAgent)
+     *                     .withTag("lucky_number", 42)
+     *                     .startManual();
+     * </code></pre>
+     */
+    SpanBuilder buildSpan(String operationName);
+
+    /**
+     * Inject a SpanContext into a `carrier` of a given type, presumably for propagation across process boundaries.
+     *
+     * <p>Example:
+     * <pre><code>
+     * Tracer tracer = ...
+     * Span clientSpan = ...
+     * TextMap httpHeadersCarrier = new AnHttpHeaderCarrier(httpRequest);
+     * tracer.inject(span.context(), Format.Builtin.HTTP_HEADERS, httpHeadersCarrier);
+     * </code></pre>
+     *
+     * @param <C> the carrier type, which also parametrizes the Format.
+     * @param spanContext the SpanContext instance to inject into the carrier
+     * @param format the Format of the carrier
+     * @param carrier the carrier for the SpanContext state. All Tracer.inject() implementations must support
+     *                io.opentracing.propagation.TextMap and java.nio.ByteBuffer.
+     *
+     * @see io.opentracing.propagation.Format
+     * @see io.opentracing.propagation.Format.Builtin
+     */
+    <C> void inject(SpanContext spanContext, Format<C> format, C carrier);
+
+    /**
+     * Extract a SpanContext from a `carrier` of a given type, presumably after propagation across a process boundary.
+     *
+     * <p>Example:
+     * <pre><code>
+     * Tracer tracer = ...
+     * TextMap httpHeadersCarrier = new AnHttpHeaderCarrier(httpRequest);
+     * SpanContext spanCtx = tracer.extract(Format.Builtin.HTTP_HEADERS, httpHeadersCarrier);
+     * ... = tracer.buildSpan('...').asChildOf(spanCtx).startActive();
+     * </code></pre>
+     *
+     * If the span serialized state is invalid (corrupt, wrong version, etc) inside the carrier this will result in an
+     * IllegalArgumentException.
+     *
+     * @param <C> the carrier type, which also parametrizes the Format.
+     * @param format the Format of the carrier
+     * @param carrier the carrier for the SpanContext state. All Tracer.extract() implementations must support
+     *                io.opentracing.propagation.TextMap and java.nio.ByteBuffer.
+     *
+     * @return the SpanContext instance holding context to create a Span.
+     *
+     * @see io.opentracing.propagation.Format
+     * @see io.opentracing.propagation.Format.Builtin
+     */
+    <C> SpanContext extract(Format<C> format, C carrier);
+
+
+    interface SpanBuilder {
+
+        /**
+         * A shorthand for addReference(References.CHILD_OF, parent).
+         *
+         * <p>
+         * If parent==null, this is a noop.
+         */
+        SpanBuilder asChildOf(SpanContext parent);
+
+        /**
+         * A shorthand for addReference(References.CHILD_OF, parent.context()).
+         *
+         * <p>
+         * If parent==null, this is a noop.
+         */
+        SpanBuilder asChildOf(BaseSpan<?> parent);
+
+        /**
+         * Add a reference from the Span being built to a distinct (usually parent) Span. May be called multiple times
+         * to represent multiple such References.
+         *
+         * <p>
+         * If
+         * <ul>
+         * <li>the {@link Tracer}'s {@link ActiveSpanSource#activeSpan()} is not null, and
+         * <li>no <b>explicit</b> references are added via {@link SpanBuilder#addReference}, and
+         * <li>{@link SpanBuilder#ignoreActiveSpan()} is not invoked,
+         * </ul>
+         * ... then an inferred {@link References#CHILD_OF} reference is created to the
+         * {@link ActiveSpanSource#activeSpan()} {@link SpanContext} when either {@link SpanBuilder#startActive()} or
+         * {@link SpanBuilder#startManual} is invoked.
+         *
+         * @param referenceType the reference type, typically one of the constants defined in References
+         * @param referencedContext the SpanContext being referenced; e.g., for a References.CHILD_OF referenceType, the
+         *                          referencedContext is the parent. If referencedContext==null, the call to
+         *                          {@link #addReference} is a noop.
+         *
+         * @see io.opentracing.References
+         */
+        SpanBuilder addReference(String referenceType, SpanContext referencedContext);
+
+        /**
+         * Do not create an implicit {@link References#CHILD_OF} reference to the {@link ActiveSpanSource#activeSpan}).
+         */
+        SpanBuilder ignoreActiveSpan();
+
+        /** Same as {@link Span#setTag(String, String)}, but for the span being built. */
+        SpanBuilder withTag(String key, String value);
+
+        /** Same as {@link Span#setTag(String, boolean)}, but for the span being built. */
+        SpanBuilder withTag(String key, boolean value);
+
+        /** Same as {@link Span#setTag(String, Number)}, but for the span being built. */
+        SpanBuilder withTag(String key, Number value);
+
+        /** Specify a timestamp of when the Span was started, represented in microseconds since epoch. */
+        SpanBuilder withStartTimestamp(long microseconds);
+
+        /**
+         * Returns a newly started and activated {@link ActiveSpan}.
+         *
+         * <p>
+         * The returned {@link ActiveSpan} supports try-with-resources. For example:
+         * <pre><code>
+         *     try (ActiveSpan span = tracer.buildSpan("...").startActive()) {
+         *         // (Do work)
+         *         span.setTag( ... );  // etc, etc
+         *     }  // Span finishes automatically unless deferred via {@link ActiveSpan#capture}
+         * </code></pre>
+         *
+         * <p>
+         * If
+         * <ul>
+         * <li>the {@link Tracer}'s {@link ActiveSpanSource#activeSpan()} is not null, and
+         * <li>no <b>explicit</b> references are added via {@link SpanBuilder#addReference}, and
+         * <li>{@link SpanBuilder#ignoreActiveSpan()} is not invoked,
+         * </ul>
+         * ... then an inferred {@link References#CHILD_OF} reference is created to the
+         * {@link ActiveSpanSource#activeSpan()}'s {@link SpanContext} when either
+         * {@link SpanBuilder#startManual()} or {@link SpanBuilder#startActive} is invoked.
+         *
+         * <p>
+         * Note: {@link SpanBuilder#startActive()} is a shorthand for
+         * {@code tracer.makeActive(spanBuilder.startManual())}.
+         *
+         * @return an {@link ActiveSpan}, already registered via the {@link ActiveSpanSource}
+         *
+         * @see ActiveSpanSource
+         * @see ActiveSpan
+         */
+        ActiveSpan startActive();
+
+        /**
+         * Like {@link #startActive()}, but the returned {@link Span} has not been registered via the
+         * {@link ActiveSpanSource}.
+         *
+         * @see SpanBuilder#startActive()
+         * @return the newly-started Span instance, which has *not* been automatically registered
+         *         via the {@link ActiveSpanSource}
+         */
+        Span startManual();
+
+        /**
+         * @deprecated use {@link #startManual} or {@link #startActive} instead.
+         */
+        @Deprecated
+        Span start();
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/log/Fields.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/log/Fields.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.log;
+
+/**
+ * The following log fields are recommended for instrumentors who are trying to capture more
+ * information about a logged event. Tracers may expose additional features based on these
+ * standardized data points.
+ *
+ * @see <a href="https://github.com/opentracing/specification/blob/master/semantic_conventions.md">https://github.com/opentracing/specification/blob/master/semantic_conventions.md</a>
+ */
+public class Fields {
+    private Fields() {
+    }
+
+    /**
+     * The type or "kind" of an error (only for event="error" logs). E.g., "Exception", "OSError"
+     */
+    public static final String ERROR_KIND = "error.kind";
+
+    /**
+     * The actual Throwable/Exception/Error object instance itself. E.g., A java.lang.UnsupportedOperationException instance
+     */
+    public static final String ERROR_OBJECT = "error.object";
+
+    /**
+     * A stable identifier for some notable moment in the lifetime of a Span. For instance, a mutex
+     * lock acquisition or release or the sorts of lifetime events in a browser page load described
+     * in the Performance.timing specification. E.g., from Zipkin, "cs", "sr", "ss", or "cr". Or,
+     * more generally, "initialized" or "timed out". For errors, "error"
+     */
+    public static final String EVENT = "event";
+
+    /**
+     * A concise, human-readable, one-line message explaining the event. E.g., "Could not connect
+     * to backend", "Cache invalidation succeeded"
+     */
+    public static final String MESSAGE = "message";
+
+    /**
+     * A stack trace in platform-conventional format; may or may not pertain to an error. 
+     */
+    public static final String STACK = "stack";
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/mock/MockSpan.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/mock/MockSpan.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.mock;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+
+/**
+ * MockSpans are created via MockTracer.buildSpan(...), but they are also returned via calls to
+ * MockTracer.finishedSpans(). They provide accessors to all Span state.
+ *
+ * @see MockTracer#finishedSpans()
+ */
+public final class MockSpan implements Span {
+    // A simple-as-possible (consecutive for repeatability) id generator.
+    private static AtomicLong nextId = new AtomicLong(0);
+
+    private final MockTracer mockTracer;
+    private MockContext context;
+    private final long parentId; // 0 if there's no parent.
+    private final long startMicros;
+    private boolean finished;
+    private long finishMicros;
+    private final Map<String, Object> tags;
+    private final List<LogEntry> logEntries = new ArrayList<>();
+    private String operationName;
+
+    private final List<RuntimeException> errors = new ArrayList<>();
+
+    public String operationName() {
+        return this.operationName;
+    }
+
+    @Override
+    public MockSpan setOperationName(String operationName) {
+        finishedCheck("Setting operationName {%s} on already finished span", operationName);
+        this.operationName = operationName;
+        return this;
+    }
+
+    /**
+     * TODO: Support multiple parents in this API.
+     *
+     * @return the spanId of the Span's parent context, or 0 if no such parent exists.
+     *
+     * @see MockContext#spanId()
+     */
+    public long parentId() {
+        return parentId;
+    }
+    public long startMicros() {
+        return startMicros;
+    }
+    /**
+     * @return the finish time of the Span; only valid after a call to finish().
+     */
+    public long finishMicros() {
+        assert finishMicros > 0 : "must call finish() before finishMicros()";
+        return finishMicros;
+    }
+
+    /**
+     * @return a copy of all tags set on this Span.
+     */
+    public Map<String, Object> tags() {
+        return new HashMap<>(this.tags);
+    }
+    /**
+     * @return a copy of all log entries added to this Span.
+     */
+    public List<LogEntry> logEntries() {
+        return new ArrayList<>(this.logEntries);
+    }
+
+    /**
+     * @return a copy of exceptions thrown by this class (e.g. adding a tag after span is finished).
+     */
+    public List<RuntimeException> generatedErrors() {
+        return new ArrayList<>(errors);
+    }
+
+    @Override
+    public synchronized MockContext context() {
+        return this.context;
+    }
+
+    @Override
+    public void finish() {
+        this.finish(nowMicros());
+    }
+
+    @Override
+    public synchronized void finish(long finishMicros) {
+        finishedCheck("Finishing already finished span");
+        this.finishMicros = finishMicros;
+        this.mockTracer.appendFinishedSpan(this);
+        this.finished = true;
+    }
+
+    @Override
+    public MockSpan setTag(String key, String value) {
+        return setObjectTag(key, value);
+    }
+
+    @Override
+    public MockSpan setTag(String key, boolean value) {
+        return setObjectTag(key, value);
+    }
+
+    @Override
+    public MockSpan setTag(String key, Number value) {
+        return setObjectTag(key, value);
+    }
+
+    private synchronized MockSpan setObjectTag(String key, Object value) {
+        finishedCheck("Adding tag {%s:%s} to already finished span", key, value);
+        tags.put(key, value);
+        return this;
+    }
+
+    @Override
+    public final Span log(Map<String, ?> fields) {
+        return log(nowMicros(), fields);
+    }
+
+    @Override
+    public final synchronized MockSpan log(long timestampMicros, Map<String, ?> fields) {
+        finishedCheck("Adding logs %s at %d to already finished span", fields, timestampMicros);
+        this.logEntries.add(new LogEntry(timestampMicros, fields));
+        return this;
+    }
+
+    @Override
+    public MockSpan log(String event) {
+        return this.log(nowMicros(), event);
+    }
+
+    @Override
+    public MockSpan log(long timestampMicroseconds, String event) {
+        return this.log(timestampMicroseconds, Collections.singletonMap("event", event));
+    }
+
+    @Override
+    public synchronized Span setBaggageItem(String key, String value) {
+        finishedCheck("Adding baggage {%s:%s} to already finished span", key, value);
+        this.context = this.context.withBaggageItem(key, value);
+        return this;
+    }
+
+    @Override
+    public synchronized String getBaggageItem(String key) {
+        return this.context.getBaggageItem(key);
+    }
+
+    /**
+     * MockContext implements a Dapper-like opentracing.SpanContext with a trace- and span-id.
+     *
+     * Note that parent ids are part of the MockSpan, not the MockContext (since they do not need to propagate
+     * between processes).
+     */
+    public static final class MockContext implements SpanContext {
+        private final long traceId;
+        private final Map<String, String> baggage;
+        private final long spanId;
+
+        /**
+         * A package-protected constructor to create a new MockContext. This should only be called by MockSpan and/or
+         * MockTracer.
+         *
+         * @param baggage the MockContext takes ownership of the baggage parameter
+         *
+         * @see MockContext#withBaggageItem(String, String)
+         */
+        public MockContext(long traceId, long spanId, Map<String, String> baggage) {
+            this.baggage = baggage;
+            this.traceId = traceId;
+            this.spanId = spanId;
+        }
+
+        public String getBaggageItem(String key) { return this.baggage.get(key); }
+        public long traceId() { return traceId; }
+        public long spanId() { return spanId; }
+
+        /**
+         * Create and return a new (immutable) MockContext with the added baggage item.
+         */
+        public MockContext withBaggageItem(String key, String val) {
+            Map<String, String> newBaggage = new HashMap<>(this.baggage);
+            newBaggage.put(key, val);
+            return new MockContext(this.traceId, this.spanId, newBaggage);
+        }
+
+        @Override
+        public Iterable<Map.Entry<String, String>> baggageItems() {
+            return baggage.entrySet();
+        }
+    }
+
+    public static final class LogEntry {
+        private final long timestampMicros;
+        private final Map<String, ?> fields;
+
+        public LogEntry(long timestampMicros, Map<String, ?> fields) {
+            this.timestampMicros = timestampMicros;
+            this.fields = fields;
+        }
+
+        public long timestampMicros() {
+            return timestampMicros;
+        }
+
+        public Map<String, ?> fields() {
+            return fields;
+        }
+    }
+
+    MockSpan(MockTracer tracer, String operationName, long startMicros, Map<String, Object> initialTags, MockContext parent) {
+        this.mockTracer = tracer;
+        this.operationName = operationName;
+        this.startMicros = startMicros;
+        if (initialTags == null) {
+            this.tags = new HashMap<>();
+        } else {
+            this.tags = new HashMap<>(initialTags);
+        }
+        if (parent == null) {
+            // We're a root Span.
+            this.context = new MockContext(nextId(), nextId(), new HashMap<String, String>());
+            this.parentId = 0;
+        } else {
+            // We're a child Span.
+            this.context = new MockContext(parent.traceId, nextId(), parent.baggage);
+            this.parentId = parent.spanId;
+        }
+    }
+
+    static long nextId() {
+        return nextId.addAndGet(1);
+    }
+
+    static long nowMicros() {
+        return System.currentTimeMillis() * 1000;
+    }
+
+    private synchronized void finishedCheck(String format, Object... args) {
+        if (finished) {
+            RuntimeException ex = new IllegalStateException(String.format(format, args));
+            errors.add(ex);
+            throw ex;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+                "traceId:" + context.traceId() +
+                ", spanId:" + context.spanId() +
+                ", parentId:" + parentId +
+                ", operationName:\"" + operationName + "\"}";
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/mock/MockTracer.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/mock/MockTracer.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.mock;
+
+import io.opentracing.v_030.References;
+import io.opentracing.v_030.propagation.Format;
+import io.opentracing.v_030.propagation.TextMap;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.ActiveSpanSource;
+import io.opentracing.v_030.BaseSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.noop.NoopActiveSpanSource;
+import io.opentracing.v_030.util.ThreadLocalActiveSpanSource;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MockTracer makes it easy to test the semantics of OpenTracing instrumentation.
+ *
+ * By using a MockTracer as an io.opentracing.v_030.Tracer implementation for unittests, a developer can assert that Span
+ * properties and relationships with other Spans are defined as expected by instrumentation code.
+ *
+ * The MockTracerTest has simple usage examples.
+ */
+public class MockTracer implements Tracer {
+    private List<MockSpan> finishedSpans = new ArrayList<>();
+    private final Propagator propagator;
+    private ActiveSpanSource spanSource;
+
+    public MockTracer() {
+        this(new ThreadLocalActiveSpanSource(), Propagator.PRINTER);
+    }
+
+    public MockTracer(ActiveSpanSource spanSource) {
+        this(spanSource, Propagator.PRINTER);
+    }
+
+    public MockTracer(ActiveSpanSource spanSource, Propagator propagator) {
+        this.propagator = propagator;
+        this.spanSource = spanSource;
+    }
+
+    /**
+     * Create a new MockTracer that passes through any calls to inject() and/or extract().
+     */
+    public MockTracer(Propagator propagator) {
+        this(NoopActiveSpanSource.INSTANCE, propagator);
+    }
+
+    /**
+     * Clear the finishedSpans() queue.
+     *
+     * Note that this does *not* have any effect on Spans created by MockTracer that have not finish()ed yet; those
+     * will still be enqueued in finishedSpans() when they finish().
+     */
+    public synchronized void reset() {
+        this.finishedSpans.clear();
+    }
+
+    /**
+     * @return a copy of all finish()ed MockSpans started by this MockTracer (since construction or the last call to
+     * MockTracer.reset()).
+     *
+     * @see MockTracer#reset()
+     */
+    public synchronized List<MockSpan> finishedSpans() {
+        return new ArrayList<>(this.finishedSpans);
+    }
+
+    /**
+     * Noop method called on {@link Span#finish()}.
+     */
+    protected void onSpanFinished(MockSpan mockSpan) {
+    }
+
+    @Override
+    public ActiveSpan activeSpan() {
+        return spanSource.activeSpan();
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        return spanSource.makeActive(span);
+    }
+
+    /**
+     * Propagator allows the developer to intercept and verify any calls to inject() and/or extract().
+     *
+     * By default, MockTracer uses Propagator.PRINTER which simply logs such calls to System.out.
+     *
+     * @see MockTracer#MockTracer(Propagator)
+     */
+    public interface Propagator {
+        <C> void inject(MockSpan.MockContext ctx, Format<C> format, C carrier);
+        <C> MockSpan.MockContext extract(Format<C> format, C carrier);
+
+        Propagator PRINTER = new Propagator() {
+            @Override
+            public <C> void inject(MockSpan.MockContext ctx, Format<C> format, C carrier) {
+                System.out.println("inject(" + ctx + ", " + format + ", " + carrier + ")");
+            }
+
+            @Override
+            public <C> MockSpan.MockContext extract(Format<C> format, C carrier) {
+                System.out.println("extract(" + format + ", " + carrier + ")");
+                return null;
+            }
+        };
+
+        Propagator TEXT_MAP = new Propagator() {
+            public static final String SPAN_ID_KEY = "spanid";
+            public static final String TRACE_ID_KEY = "traceid";
+            public static final String BAGGAGE_KEY_PREFIX = "baggage-";
+
+            @Override
+            public <C> void inject(MockSpan.MockContext ctx, Format<C> format, C carrier) {
+                if (carrier instanceof TextMap) {
+                    TextMap textMap = (TextMap) carrier;
+                    for (Map.Entry<String, String> entry : ctx.baggageItems()) {
+                        textMap.put(BAGGAGE_KEY_PREFIX + entry.getKey(), entry.getValue());
+                    }
+                    textMap.put(SPAN_ID_KEY, String.valueOf(ctx.spanId()));
+                    textMap.put(TRACE_ID_KEY, String.valueOf(ctx.traceId()));
+                } else {
+                    throw new IllegalArgumentException("Unknown carrier");
+                }
+            }
+
+            @Override
+            public <C> MockSpan.MockContext extract(Format<C> format, C carrier) {
+                Long traceId = null;
+                Long spanId = null;
+                Map<String, String> baggage = new HashMap<>();
+
+                if (carrier instanceof TextMap) {
+                    TextMap textMap = (TextMap) carrier;
+                    for (Map.Entry<String, String> entry : textMap) {
+                        if (TRACE_ID_KEY.equals(entry.getKey())) {
+                            traceId = Long.valueOf(entry.getValue());
+                        } else if (SPAN_ID_KEY.equals(entry.getKey())) {
+                            spanId = Long.valueOf(entry.getValue());
+                        } else if (entry.getKey().startsWith(BAGGAGE_KEY_PREFIX)){
+                            String key = entry.getKey().substring((BAGGAGE_KEY_PREFIX.length()));
+                            baggage.put(key, entry.getValue());
+                        }
+                    }
+                } else {
+                    throw new IllegalArgumentException("Unknown carrier");
+                }
+
+                if (traceId != null && spanId != null) {
+                    return new MockSpan.MockContext(traceId, spanId, baggage);
+                }
+
+                return null;
+            }
+        };
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) {
+        return new SpanBuilder(operationName);
+    }
+
+    private SpanContext activeSpanContext() {
+        ActiveSpan handle = this.spanSource.activeSpan();
+        if (handle == null) {
+            return null;
+        }
+
+        return handle.context();
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+        this.propagator.inject((MockSpan.MockContext)spanContext, format, carrier);
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        return this.propagator.extract(format, carrier);
+    }
+
+    synchronized void appendFinishedSpan(MockSpan mockSpan) {
+        this.finishedSpans.add(mockSpan);
+        this.onSpanFinished(mockSpan);
+    }
+
+    public final class SpanBuilder implements Tracer.SpanBuilder {
+        private final String operationName;
+        private long startMicros;
+        private MockSpan.MockContext firstParent;
+        private boolean ignoringActiveSpan;
+        private Map<String, Object> initialTags = new HashMap<>();
+
+        SpanBuilder(String operationName) {
+            this.operationName = operationName;
+        }
+
+        @Override
+        public SpanBuilder asChildOf(SpanContext parent) {
+            return addReference(References.CHILD_OF, parent);
+        }
+
+        @Override
+        public SpanBuilder asChildOf(BaseSpan parent) {
+            return addReference(References.CHILD_OF, parent.context());
+        }
+
+        @Override
+        public SpanBuilder ignoreActiveSpan() {
+            ignoringActiveSpan = true;
+            return this;
+        }
+
+        @Override
+        public SpanBuilder addReference(String referenceType, SpanContext referencedContext) {
+            if (firstParent == null && (
+                    referenceType.equals(References.CHILD_OF) || referenceType.equals(References.FOLLOWS_FROM))) {
+                this.firstParent = (MockSpan.MockContext)referencedContext;
+            }
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withTag(String key, String value) {
+            this.initialTags.put(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withTag(String key, boolean value) {
+            this.initialTags.put(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withTag(String key, Number value) {
+            this.initialTags.put(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withStartTimestamp(long microseconds) {
+            this.startMicros = microseconds;
+            return this;
+        }
+
+        @Override
+        public MockSpan start() {
+            return startManual();
+        }
+
+        @Override
+        public ActiveSpan startActive() {
+            MockSpan span = this.startManual();
+            return spanSource.makeActive(span);
+        }
+
+        @Override
+        public MockSpan startManual() {
+            if (this.startMicros == 0) {
+                this.startMicros = MockSpan.nowMicros();
+            }
+            if (firstParent == null && !ignoringActiveSpan) {
+                firstParent = (MockSpan.MockContext) activeSpanContext();
+            }
+            return new MockSpan(MockTracer.this, operationName, startMicros, initialTags, firstParent);
+        }
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopActiveSpanSource.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopActiveSpanSource.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.noop;
+
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.ActiveSpanSource;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+
+import java.util.Map;
+
+public interface NoopActiveSpanSource extends ActiveSpanSource {
+    NoopActiveSpanSource INSTANCE = new NoopActiveSpanSourceImpl();
+
+    interface NoopActiveSpan extends ActiveSpan {
+        NoopActiveSpanSource.NoopActiveSpan INSTANCE = new NoopActiveSpanSourceImpl.NoopActiveSpanImpl();
+    }
+    interface NoopContinuation extends ActiveSpan.Continuation {
+        NoopActiveSpanSource.NoopContinuation INSTANCE = new NoopActiveSpanSourceImpl.NoopContinuationImpl();
+    }
+}
+
+/**
+ * A noop (i.e., cheap-as-possible) implementation of an ActiveSpanSource.
+ */
+class NoopActiveSpanSourceImpl implements NoopActiveSpanSource {
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+    }
+
+    @Override
+    public ActiveSpan activeSpan() { return null; }
+
+    static class NoopActiveSpanImpl implements NoopActiveSpanSource.NoopActiveSpan {
+        @Override
+        public void deactivate() {}
+
+        @Override
+        public Continuation capture() {
+            return NoopActiveSpanSource.NoopContinuation.INSTANCE;
+        }
+
+        @Override
+        public SpanContext context() {
+            return NoopSpanContextImpl.INSTANCE;
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public NoopActiveSpan setTag(String key, String value) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan setTag(String key, boolean value) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan setTag(String key, Number value) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan log(Map<String, ?> fields) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan log(long timestampMicroseconds, Map<String, ?> fields) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan log(String event) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan log(long timestampMicroseconds, String event) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public NoopActiveSpan setBaggageItem(String key, String value) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+
+        @Override
+        public String getBaggageItem(String key) {
+            return null;
+        }
+
+        @Override
+        public NoopActiveSpan setOperationName(String operationName) {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+    }
+
+    static class NoopContinuationImpl implements NoopActiveSpanSource.NoopContinuation {
+        @Override
+        public ActiveSpan activate() {
+            return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+        }
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopSpan.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopSpan.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.noop;
+
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+
+import java.util.Map;
+
+public interface NoopSpan extends Span {
+    static final NoopSpan INSTANCE = new NoopSpanImpl();
+}
+
+final class NoopSpanImpl implements NoopSpan {
+
+    @Override
+    public SpanContext context() { return NoopSpanContextImpl.INSTANCE; }
+
+    @Override
+    public void finish() {}
+
+    @Override
+    public void finish(long finishMicros) {}
+
+    @Override
+    public NoopSpan setTag(String key, String value) { return this; }
+
+    @Override
+    public NoopSpan setTag(String key, boolean value) { return this; }
+
+    @Override
+    public NoopSpan setTag(String key, Number value) { return this; }
+
+    @Override
+    public NoopSpan log(Map<String, ?> fields) { return this; }
+
+    @Override
+    public NoopSpan log(long timestampMicroseconds, Map<String, ?> fields) { return this; }
+
+    @Override
+    public NoopSpan log(String event) { return this; }
+
+    @Override
+    public NoopSpan log(long timestampMicroseconds, String event) { return this; }
+
+    @Override
+    public NoopSpan setBaggageItem(String key, String value) { return this; }
+
+    @Override
+    public String getBaggageItem(String key) { return null; }
+
+    @Override
+    public NoopSpan setOperationName(String operationName) { return this; }
+
+    @Override
+    public String toString() { return NoopSpan.class.getSimpleName(); }
+}
+

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopSpanBuilder.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopSpanBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.noop;
+
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.BaseSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+
+import java.util.Collections;
+import java.util.Map;
+
+public interface NoopSpanBuilder extends Tracer.SpanBuilder, NoopSpanContext {
+    static final NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
+}
+
+final class NoopSpanBuilderImpl implements NoopSpanBuilder {
+
+    @Override
+    public Tracer.SpanBuilder addReference(String refType, SpanContext referenced) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder asChildOf(SpanContext parent) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder ignoreActiveSpan() { return this; }
+
+    @Override
+    public Tracer.SpanBuilder asChildOf(BaseSpan parent) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, String value) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, boolean value) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, Number value) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withStartTimestamp(long microseconds) {
+        return this;
+    }
+
+    @Override
+    public Span start() {
+        return startManual();
+    }
+
+    @Override
+    public ActiveSpan startActive() {
+        return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+    }
+
+    @Override
+    public Span startManual() {
+        return NoopSpanImpl.INSTANCE;
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> baggageItems() {
+        return Collections.EMPTY_MAP.entrySet();
+    }
+
+    @Override
+    public String toString() { return NoopSpanBuilder.class.getSimpleName(); }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopSpanContext.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopSpanContext.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.noop;
+
+import io.opentracing.v_030.SpanContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+
+public interface NoopSpanContext extends SpanContext {
+}
+
+final class NoopSpanContextImpl implements NoopSpanContext {
+    static final NoopSpanContextImpl INSTANCE = new NoopSpanContextImpl();
+
+    @Override
+    public Iterable<Map.Entry<String, String>> baggageItems() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String toString() { return NoopSpanContext.class.getSimpleName(); }
+
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopTracer.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopTracer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.noop;
+
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.propagation.Format;
+
+public interface NoopTracer extends Tracer {
+}
+
+final class NoopTracerImpl implements NoopTracer {
+    final static NoopTracer INSTANCE = new NoopTracerImpl();
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) { return NoopSpanBuilderImpl.INSTANCE; }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {}
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) { return NoopSpanBuilderImpl.INSTANCE; }
+
+    @Override
+    public String toString() { return NoopTracer.class.getSimpleName(); }
+
+    @Override
+    public ActiveSpan activeSpan() {
+        return null;
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        return NoopActiveSpanSource.NoopActiveSpan.INSTANCE;
+    }
+}
+

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopTracerFactory.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/noop/NoopTracerFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.noop;
+
+public final class NoopTracerFactory {
+    
+    public static NoopTracer create() {
+        return NoopTracerImpl.INSTANCE;
+    }
+
+    private NoopTracerFactory() {}
+}
+

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/propagation/Format.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/propagation/Format.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.propagation;
+
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Format instances control the behavior of Tracer.inject and Tracer.extract (and also constrain the type of the
+ * carrier parameter to same).
+ *
+ * Most OpenTracing users will only reference the Format.Builtin constants. For example:
+ *
+ * <pre><code>
+ * Tracer tracer = ...
+ * io.opentracing.propagation.HttpHeaders httpCarrier = new AnHttpHeaderCarrier(httpRequest);
+ * SpanContext spanCtx = tracer.extract(Format.Builtin.HTTP_HEADERS, httpHeaderReader);
+ * </code></pre>
+ *
+ * @see Tracer#inject(SpanContext, Format, Object)
+ * @see Tracer#extract(Format, Object)
+ */
+public interface Format<C> {
+    final class Builtin<C> implements Format<C> {
+        private final String name;
+
+        private Builtin(String name) {
+            this.name = name;
+        }
+
+        /**
+         * The TEXT_MAP format allows for arbitrary String-&gt;String map encoding of SpanContext state for
+         * Tracer.inject and Tracer.extract.
+         *
+         * Unlike HTTP_HEADERS, the builtin TEXT_MAP format expresses no constraints on keys or values.
+         *
+         * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
+         * @see io.opentracing.Tracer#extract(Format, Object)
+         * @see Format
+         * @see Builtin#HTTP_HEADERS
+         */
+        public final static Format<TextMap> TEXT_MAP = new Builtin<TextMap>("TEXT_MAP");
+
+        /**
+         * The HTTP_HEADERS format allows for HTTP-header-compatible String-&gt;String map encoding of SpanContext state
+         * for Tracer.inject and Tracer.extract.
+         *
+         * I.e., keys written to the TextMap MUST be suitable for HTTP header keys (which are poorly defined but
+         * certainly restricted); and similarly for values (i.e., URL-escaped and "not too long").
+         *
+         * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
+         * @see io.opentracing.Tracer#extract(Format, Object)
+         * @see Format
+         * @see Builtin#TEXT_MAP
+         */
+        public final static Format<TextMap> HTTP_HEADERS = new Builtin<TextMap>("HTTP_HEADERS");
+
+        /**
+         * The BINARY format allows for unconstrained binary encoding of SpanContext state for Tracer.inject and
+         * Tracer.extract.
+         *
+         * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
+         * @see io.opentracing.Tracer#extract(Format, Object)
+         * @see Format
+         */
+        public final static Format<ByteBuffer> BINARY = new Builtin<ByteBuffer>("BINARY");
+
+        /**
+         * @return Short name for built-in formats as they tend to show up in exception messages.
+         */
+        @Override
+        public String toString() {
+            return Builtin.class.getSimpleName() + "." + name;
+        }
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/propagation/TextMap.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/propagation/TextMap.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.propagation;
+
+import io.opentracing.v_030.SpanContext;
+import java.util.Iterator;
+
+import java.util.Map;
+
+/**
+ * TextMap is a built-in carrier for Tracer.inject() and Tracer.extract(). TextMap implementations allows Tracers to
+ * read and write key:value String pairs from arbitrary underlying sources of data.
+ *
+ * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
+ * @see io.opentracing.Tracer#extract(Format, Object)
+ */
+public interface TextMap extends Iterable<Map.Entry<String, String>> {
+    /**
+     * Gets an iterator over arbitrary key:value pairs from the TextMapReader.
+     *
+     * @return entries in the TextMap backing store; note that for some Formats, the iterator may include entries that
+     * were never injected by a Tracer implementation (e.g., unrelated HTTP headers)
+     *
+     * @see io.opentracing.Tracer#extract(Format, Object)
+     * @see Format.Builtin#TEXT_MAP
+     * @see Format.Builtin#HTTP_HEADERS
+     */
+    Iterator<Map.Entry<String,String>> iterator();
+
+    /**
+     * Puts a key:value pair into the TextMapWriter's backing store.
+     *
+     * @param key a String, possibly with constraints dictated by the particular Format this TextMap is paired with
+     * @param value a String, possibly with constraints dictated by the particular Format this TextMap is paired with
+     *
+     * @see io.opentracing.Tracer#inject(io.opentracing.SpanContext, Format, Object)
+     * @see Format.Builtin#TEXT_MAP
+     * @see Format.Builtin#HTTP_HEADERS
+     */
+    void put(String key, String value);
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/propagation/TextMapExtractAdapter.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/propagation/TextMapExtractAdapter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.propagation;
+
+import io.opentracing.v_030.Tracer;
+import java.util.Iterator;
+
+import java.util.Map;
+
+/**
+ * A TextMap carrier for use with Tracer.extract() ONLY (it has no mutating methods).
+ *
+ * Note that the TextMap interface can be made to wrap around arbitrary data types (not just Map&lt;String, String&gt;
+ * as illustrated here).
+ *
+ * @see Tracer#extract(Format, Object)
+ */
+public final class TextMapExtractAdapter implements TextMap {
+    private final Map<String,String> map;
+
+    public TextMapExtractAdapter(final Map<String,String> map) {
+        this.map = map;
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+        return map.entrySet().iterator();
+    }
+
+    @Override
+    public void put(String key, String value) {
+        throw new UnsupportedOperationException("TextMapInjectAdapter should only be used with Tracer.extract()");
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/propagation/TextMapInjectAdapter.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/propagation/TextMapInjectAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.propagation;
+
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import java.util.Iterator;
+
+import java.util.Map;
+
+/**
+ * A TextMap carrier for use with Tracer.inject() ONLY (it has no read methods).
+ *
+ * Note that the TextMap interface can be made to wrap around arbitrary data types (not just Map&lt;String, String&gt;
+ * as illustrated here).
+ *
+ * @see Tracer#inject(SpanContext, Format, Object)
+ */
+public final class TextMapInjectAdapter implements TextMap {
+    private final Map<String,String> map;
+
+    public TextMapInjectAdapter(final Map<String,String> map) {
+        this.map = map;
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+        throw new UnsupportedOperationException("TextMapInjectAdapter should only be used with Tracer.inject()");
+    }
+
+    @Override
+    public void put(String key, String value) {
+        this.map.put(key, value);
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/shim/ActiveSpanShim.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/shim/ActiveSpanShim.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.Scope;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.ActiveSpan;
+
+import java.util.Map;
+
+public class ActiveSpanShim implements ActiveSpan, SpanWrapper {
+    final Scope scope;
+    final SpanContext context;
+
+    public ActiveSpanShim(Scope scope) {
+        if (scope == null)
+            throw new IllegalArgumentException("scope");
+
+        this.scope = scope;
+        this.context = new SpanContextShim(scope.span().context());
+    }
+
+    protected Scope scope() {
+        return scope;
+    }
+
+    @Override
+    public io.opentracing.Span span() {
+        return scope.span();
+    }
+
+    @Override
+    public void deactivate() {
+        scope.close();
+    }
+
+    @Override
+    public void close() {
+        deactivate();
+    }
+
+    @Override
+    public Continuation capture() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SpanContext context() {
+        return context;
+    }
+
+    @Override
+    public ActiveSpanShim setTag(String key, String value) {
+        scope.span().setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public ActiveSpanShim setTag(String key, boolean value) {
+        scope.span().setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public ActiveSpanShim setTag(String key, Number value) {
+        scope.span().setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public final ActiveSpanShim log(Map<String, ?> fields) {
+        scope.span().log(fields);
+        return this;
+    }
+
+    @Override
+    public final ActiveSpanShim log(long timestampMicros, Map<String, ?> fields) {
+        scope.span().log(timestampMicros, fields);
+        return this;
+    }
+
+    @Override
+    public ActiveSpanShim log(String event) {
+        scope.span().log(event);
+        return this;
+    }
+
+    @Override
+    public ActiveSpanShim log(long timestampMicroseconds, String event) {
+        scope.span().log(timestampMicroseconds, event);
+        return this;
+    }
+
+    @Override
+    public ActiveSpanShim setBaggageItem(String key, String value) {
+        scope.span().setBaggageItem(key, value);
+        return this;
+    }
+
+    @Override
+    public String getBaggageItem(String key) {
+        return scope.span().getBaggageItem(key);
+    }
+
+    @Override
+    public ActiveSpanShim setOperationName(String operationName) {
+        scope.span().setOperationName(operationName);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return scope.span().toString();
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/shim/BaseTracerShim.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/shim/BaseTracerShim.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.Scope;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.BaseSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.propagation.Format;
+
+import java.util.Map;
+
+public class BaseTracerShim implements Tracer {
+    final io.opentracing.Tracer tracer;
+
+    protected BaseTracerShim(io.opentracing.Tracer tracer) {
+        checkArgumentNotNull(tracer, "tracer");
+
+        this.tracer = tracer;
+    }
+
+    void checkArgumentNotNull(Object value, String errorMessage) {
+        if (value == null)
+            throw new IllegalArgumentException(errorMessage);
+    }
+
+    protected ActiveSpanShim createActiveSpanShim(Scope scope) {
+        return new ActiveSpanShim(scope);
+    }
+
+    protected SpanShim createSpanShim(io.opentracing.Span span) {
+        return new SpanShim(span);
+    }
+
+    @Override
+    public ActiveSpan activeSpan() {
+        if (tracer.scopeManager().active() == null)
+            return null;
+
+        return createActiveSpanShim(tracer.scopeManager().active());
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        checkArgumentNotNull(span, "span");
+
+        io.opentracing.Span wrappedSpan = ((SpanWrapper)span).span();
+        return createActiveSpanShim(tracer.scopeManager().activate(wrappedSpan));
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) {
+        return new SpanBuilderShim(tracer.buildSpan(operationName));
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+        checkArgumentNotNull(spanContext, "spanContext");
+
+        tracer.inject(((SpanContextShim)spanContext).context(),
+                FormatConverter.toUpstreamFormat(format),
+                FormatConverter.toUpstreamCarrier(format, carrier));
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        io.opentracing.SpanContext context = tracer.extract(FormatConverter.toUpstreamFormat(format),
+                FormatConverter.toUpstreamCarrier(format, carrier));
+        return new SpanContextShim(context);
+    }
+
+    private final class SpanBuilderShim implements Tracer.SpanBuilder {
+        io.opentracing.Tracer.SpanBuilder builder;
+
+        public SpanBuilderShim(io.opentracing.Tracer.SpanBuilder builder) {
+            this.builder = builder;
+        }
+
+        @Override
+        public SpanBuilderShim asChildOf(SpanContext parent) {
+            checkArgumentNotNull(parent, "parent");
+
+            builder.asChildOf(((SpanContextShim)parent).context());
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim asChildOf(BaseSpan<?> parent) {
+            checkArgumentNotNull(parent, "parent");
+
+            builder.asChildOf(((SpanWrapper)parent).span());
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim addReference(String referenceType, SpanContext referencedContext) {
+            checkArgumentNotNull(referencedContext, "referencedContext");
+
+            builder.addReference(referenceType, ((SpanContextShim)referencedContext).context());
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim ignoreActiveSpan() {
+            builder.ignoreActiveSpan();
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim withTag(String key, String value) {
+            builder.withTag(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim withTag(String key, boolean value) {
+            builder.withTag(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim withTag(String key, Number value) {
+            builder.withTag(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim withStartTimestamp(long microseconds) {
+            builder.withStartTimestamp(microseconds);
+            return this;
+        }
+
+        @Override
+        public ActiveSpan startActive() {
+            Scope scope = builder.startActive();
+            return createActiveSpanShim(scope);
+        }
+
+        @Override
+        public Span startManual() {
+            return createSpanShim(builder.startManual());
+        }
+
+        @Override
+        public Span start() {
+            return createSpanShim(builder.start());
+        }
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/shim/FormatConverter.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/shim/FormatConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.propagation.Format;
+import io.opentracing.v_030.propagation.TextMap;
+
+final class FormatConverter {
+    private FormatConverter() {}
+
+    public static io.opentracing.propagation.Format toUpstreamFormat(Format format) {
+        if (format == null)
+            return null; // Bail out early.
+
+        if (format == Format.Builtin.TEXT_MAP)
+            return io.opentracing.propagation.Format.Builtin.TEXT_MAP;
+        if (format == Format.Builtin.HTTP_HEADERS)
+            return io.opentracing.propagation.Format.Builtin.HTTP_HEADERS;
+        if (format == Format.Builtin.BINARY)
+            return io.opentracing.propagation.Format.Builtin.BINARY;
+
+        throw new UnsupportedOperationException("Format not supported");
+    }
+
+    public static <C> Object toUpstreamCarrier(Format format, C carrier) {
+        if (format == Format.Builtin.TEXT_MAP || format == Format.Builtin.HTTP_HEADERS)
+            return new TextMapUpstreamShim((TextMap)carrier);
+
+        return carrier;
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/shim/SpanContextShim.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/shim/SpanContextShim.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.v_030.SpanContext;
+
+import java.util.Map;
+
+class SpanContextShim implements SpanContext {
+    final io.opentracing.SpanContext context;
+
+    public SpanContextShim(io.opentracing.SpanContext context) {
+        this.context = context;
+    }
+
+    public io.opentracing.SpanContext context() {
+        return context;
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> baggageItems() {
+        return context.baggageItems();
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/shim/SpanShim.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/shim/SpanShim.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Span;
+
+import java.util.Map;
+
+public class SpanShim implements Span, SpanWrapper {
+    final io.opentracing.Span span;
+    final SpanContext context;
+
+    public SpanShim(io.opentracing.Span span) {
+        this.span = span;
+        this.context = new SpanContextShim(span().context());
+    }
+
+    @Override
+    public io.opentracing.Span span() {
+        return span;
+    }
+
+    @Override
+    public void finish() {
+        span.finish();
+    }
+
+    @Override
+    public void finish(long finishMicros) {
+        span.finish(finishMicros);
+    }
+
+    @Override
+    public SpanContext context() {
+        return context;
+    }
+
+    @Override
+    public SpanShim setTag(String key, String value) {
+        span.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public SpanShim setTag(String key, boolean value) {
+        span.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public SpanShim setTag(String key, Number value) {
+        span.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public final SpanShim log(Map<String, ?> fields) {
+        span.log(fields);
+        return this;
+    }
+
+    @Override
+    public final SpanShim log(long timestampMicros, Map<String, ?> fields) {
+        span.log(timestampMicros, fields);
+        return this;
+    }
+
+    @Override
+    public SpanShim log(String event) {
+        span.log(event);
+        return this;
+    }
+
+    @Override
+    public SpanShim log(long timestampMicroseconds, String event) {
+        span.log(timestampMicroseconds, event);
+        return this;
+    }
+
+    @Override
+    public SpanShim setBaggageItem(String key, String value) {
+        span.setBaggageItem(key, value);
+        return this;
+    }
+
+    @Override
+    public String getBaggageItem(String key) {
+        return span.getBaggageItem(key);
+    }
+
+    @Override
+    public SpanShim setOperationName(String operationName) {
+        span.setOperationName(operationName);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return span.toString();
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/shim/SpanWrapper.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/shim/SpanWrapper.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+public interface SpanWrapper {
+    io.opentracing.Span span();
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/shim/TextMapUpstreamShim.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/shim/TextMapUpstreamShim.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.v_030.propagation.TextMap;
+
+import java.util.Iterator;
+import java.util.Map;
+
+class TextMapUpstreamShim implements io.opentracing.propagation.TextMap {
+    final TextMap textMap;
+
+    public TextMapUpstreamShim(TextMap textMap) {
+        this.textMap = textMap;
+    }
+
+    public TextMap textMap() {
+        return textMap;
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+        return textMap.iterator();
+    }
+
+    @Override
+    public void put(String key, String value) {
+        textMap.put(key, value);
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/shim/TracerShim.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/shim/TracerShim.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.util.AutoFinishScope;
+import io.opentracing.util.AutoFinishScopeManager;
+import io.opentracing.v_030.ActiveSpan;
+
+public class TracerShim extends BaseTracerShim {
+    public TracerShim(io.opentracing.Tracer tracer) {
+        super(tracer);
+
+        if (!(tracer.scopeManager() instanceof AutoFinishScopeManager))
+            throw new IllegalArgumentException("tracer.scopeManager");
+    }
+
+    @Override
+    protected ActiveSpanShim createActiveSpanShim(Scope scope) {
+        return new AutoFinishActiveSpanShim(scope);
+    }
+
+    final static class AutoFinishActiveSpanShim extends ActiveSpanShim {
+        public AutoFinishActiveSpanShim(Scope scope) {
+            super(scope);
+        }
+
+        @Override
+        public Continuation capture() {
+            return new Continuation(((AutoFinishScope)scope()).capture());
+        }
+
+        private final class Continuation implements ActiveSpan.Continuation {
+            AutoFinishScope.Continuation continuation;
+
+            Continuation(AutoFinishScope.Continuation continuation) {
+                this.continuation = continuation;
+            }
+
+            @Override
+            public ActiveSpanShim activate() {
+                return new AutoFinishActiveSpanShim(continuation.activate());
+            }
+        }
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/tag/AbstractTag.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/tag/AbstractTag.java
@@ -13,7 +13,7 @@
  */
 package io.opentracing.v_030.tag;
 
-import io.opentracing.v_030.Span;
+import io.opentracing.v_030.BaseSpan;
 
 public abstract class AbstractTag<T> {
     protected final String key;
@@ -26,5 +26,5 @@ public abstract class AbstractTag<T> {
         return key;
     }
 
-    protected abstract void set(Span span, T tagValue);
+    protected abstract void set(BaseSpan<?> span, T tagValue);
 }

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/tag/AbstractTag.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/tag/AbstractTag.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.tag;
+
+import io.opentracing.v_030.Span;
+
+public abstract class AbstractTag<T> {
+    protected final String key;
+
+    public AbstractTag(String tagKey) {
+        this.key = tagKey;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    protected abstract void set(Span span, T tagValue);
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/tag/BooleanTag.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/tag/BooleanTag.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.tag;
+
+import io.opentracing.v_030.Span;
+
+public class BooleanTag extends AbstractTag<Boolean> {
+    public BooleanTag(String key) {
+        super(key);
+    }
+
+    @Override
+    public void set(Span span, Boolean tagValue) {
+        span.setTag(super.key, tagValue);
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/tag/BooleanTag.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/tag/BooleanTag.java
@@ -13,7 +13,7 @@
  */
 package io.opentracing.v_030.tag;
 
-import io.opentracing.v_030.Span;
+import io.opentracing.v_030.BaseSpan;
 
 public class BooleanTag extends AbstractTag<Boolean> {
     public BooleanTag(String key) {
@@ -21,7 +21,7 @@ public class BooleanTag extends AbstractTag<Boolean> {
     }
 
     @Override
-    public void set(Span span, Boolean tagValue) {
+    public void set(BaseSpan<?> span, Boolean tagValue) {
         span.setTag(super.key, tagValue);
     }
 }

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/tag/IntOrStringTag.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/tag/IntOrStringTag.java
@@ -13,14 +13,14 @@
  */
 package io.opentracing.v_030.tag;
 
-import io.opentracing.v_030.Span;
+import io.opentracing.v_030.BaseSpan;
 
 public class IntOrStringTag extends IntTag {
     public IntOrStringTag(String key) {
         super(key);
     }
 
-    public void set(Span span, String tagValue) {
+    public void set(BaseSpan<?> span, String tagValue) {
         span.setTag(super.key, tagValue);
     }
 }

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/tag/IntOrStringTag.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/tag/IntOrStringTag.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.tag;
+
+import io.opentracing.v_030.Span;
+
+public class IntOrStringTag extends IntTag {
+    public IntOrStringTag(String key) {
+        super(key);
+    }
+
+    public void set(Span span, String tagValue) {
+        span.setTag(super.key, tagValue);
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/tag/IntTag.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/tag/IntTag.java
@@ -13,7 +13,7 @@
  */
 package io.opentracing.v_030.tag;
 
-import io.opentracing.v_030.Span;
+import io.opentracing.v_030.BaseSpan;
 
 public class IntTag extends AbstractTag<Integer> {
     public IntTag(String key) {
@@ -21,7 +21,7 @@ public class IntTag extends AbstractTag<Integer> {
     }
 
     @Override
-    public void set(Span span, Integer tagValue) {
+    public void set(BaseSpan<?> span, Integer tagValue) {
         span.setTag(super.key, tagValue);
     }
 }

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/tag/IntTag.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/tag/IntTag.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.tag;
+
+import io.opentracing.v_030.Span;
+
+public class IntTag extends AbstractTag<Integer> {
+    public IntTag(String key) {
+        super(key);
+    }
+
+    @Override
+    public void set(Span span, Integer tagValue) {
+        span.setTag(super.key, tagValue);
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/tag/StringTag.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/tag/StringTag.java
@@ -13,7 +13,7 @@
  */
 package io.opentracing.v_030.tag;
 
-import io.opentracing.v_030.Span;
+import io.opentracing.v_030.BaseSpan;
 
 public class StringTag extends AbstractTag<String> {
     public StringTag(String key) {
@@ -21,11 +21,11 @@ public class StringTag extends AbstractTag<String> {
     }
 
     @Override
-    public void set(Span span, String tagValue) {
+    public void set(BaseSpan<?> span, String tagValue) {
         span.setTag(super.key, tagValue);
     }
 
-    public void set(Span span, StringTag tag) {
+    public void set(BaseSpan<?> span, StringTag tag) {
         span.setTag(super.key, tag.key);
     }
 }

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/tag/StringTag.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/tag/StringTag.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.tag;
+
+import io.opentracing.v_030.Span;
+
+public class StringTag extends AbstractTag<String> {
+    public StringTag(String key) {
+        super(key);
+    }
+
+    @Override
+    public void set(Span span, String tagValue) {
+        span.setTag(super.key, tagValue);
+    }
+
+    public void set(Span span, StringTag tag) {
+        span.setTag(super.key, tag.key);
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/tag/Tags.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/tag/Tags.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.tag;
+
+/**
+ * The following span tags are recommended for instrumentors who are trying to capture more
+ * semantic information about the spans. Tracers may expose additional features based on these
+ * standardized data points. Tag names follow a general structure of namespacing.
+ *
+ * @see <a href="https://github.com/opentracing/specification/blob/master/semantic_conventions.md">https://github.com/opentracing/specification/blob/master/semantic_conventions.md</a>
+ */
+
+public final class Tags {
+    private Tags() {
+    }
+
+    /**
+     * A constant for setting the span kind to indicate that it represents a server span.
+     */
+    public static final String SPAN_KIND_SERVER = "server";
+
+    /**
+     * A constant for setting the span kind to indicate that it represents a client span.
+     */
+    public static final String SPAN_KIND_CLIENT = "client";
+
+    /**
+     * A constant for setting the span kind to indicate that it represents a producer span, in a messaging scenario.
+     */
+    public static final String SPAN_KIND_PRODUCER = "producer";
+
+    /**
+     * A constant for setting the span kind to indicate that it represents a consumer span, in a messaging scenario.
+     */
+    public static final String SPAN_KIND_CONSUMER = "consumer";
+
+    /**
+     * HTTP_URL records the url of the incoming request.
+     */
+    public static final StringTag HTTP_URL = new StringTag("http.url");
+
+    /**
+     * HTTP_STATUS records the http status code of the response.
+     */
+    public static final IntTag HTTP_STATUS = new IntTag("http.status_code");
+
+    /**
+     * HTTP_METHOD records the http method. Case-insensitive.
+     */
+    public static final StringTag HTTP_METHOD = new StringTag("http.method");
+
+    /**
+     * PEER_HOST_IPV4 records IPv4 host address of the peer.
+     */
+    public static final IntOrStringTag PEER_HOST_IPV4 = new IntOrStringTag("peer.ipv4");
+
+    /**
+     * PEER_HOST_IPV6 records the IPv6 host address of the peer.
+     */
+    public static final StringTag PEER_HOST_IPV6 = new StringTag("peer.ipv6");
+
+    /**
+     * PEER_SERVICE records the service name of the peer.
+     */
+    public static final StringTag PEER_SERVICE = new StringTag("peer.service");
+
+    /**
+     * PEER_HOSTNAME records the host name of the peer.
+     */
+    public static final StringTag PEER_HOSTNAME = new StringTag("peer.hostname");
+
+    /**
+     * PEER_PORT records the port number of the peer.
+     */
+    public static final IntTag PEER_PORT = new IntTag("peer.port");
+
+    /**
+     * SAMPLING_PRIORITY determines the priority of sampling this Span.
+     */
+    public static final IntTag SAMPLING_PRIORITY = new IntTag("sampling.priority");
+
+    /**
+     * SPAN_KIND hints at the relationship between spans, e.g. client/server.
+     */
+    public static final StringTag SPAN_KIND = new StringTag("span.kind");
+
+    /**
+     * COMPONENT is a low-cardinality identifier of the module, library, or package that is instrumented.
+     */
+    public static final StringTag COMPONENT = new StringTag("component");
+
+    /**
+     * ERROR indicates whether a Span ended in an error state.
+     */
+    public static final BooleanTag ERROR = new BooleanTag("error");
+
+    /**
+     * DB_TYPE indicates the type of Database.
+     * For any SQL database, "sql". For others, the lower-case database category, e.g. "cassandra", "hbase", or "redis"
+     */
+    public static final StringTag DB_TYPE = new StringTag("db.type");
+
+    /**
+     * DB_INSTANCE indicates the instance name of Database.
+     * If the jdbc.url="jdbc:mysql://127.0.0.1:3306/customers", instance name is "customers".
+     */
+    public static final StringTag DB_INSTANCE = new StringTag("db.instance");
+
+    /**
+     * DB_USER indicates the user name of Database, e.g. "readonly_user" or "reporting_user"
+     */
+    public static final StringTag DB_USER = new StringTag("db.user");
+
+    /**
+     * DB_STATEMENT records a database statement for the given database type.
+     * For db.type="SQL", "SELECT * FROM wuser_table". For db.type="redis", "SET mykey "WuValue".
+     */
+    public static final StringTag DB_STATEMENT = new StringTag("db.statement");
+
+    /**
+     * MESSAGE_BUS_DESTINATION records an address at which messages can be exchanged.
+     * E.g. A Kafka record has an associated "topic name" that can be extracted by the instrumented
+     * producer or consumer and stored using this tag.
+     */
+    public static final StringTag MESSAGE_BUS_DESTINATION = new StringTag("message_bus.destination");
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/util/GlobalTracer.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/util/GlobalTracer.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.util;
+
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.noop.NoopTracer;
+import io.opentracing.v_030.noop.NoopTracerFactory;
+import io.opentracing.v_030.propagation.Format;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Global tracer that forwards all methods to another tracer that can be
+ * configured by calling {@link #register(Tracer)}.
+ *
+ * <p>
+ * The {@linkplain #register(Tracer) register} method should only be called once
+ * during the application initialization phase.<br>
+ * If the {@linkplain #register(Tracer) register} method is never called,
+ * the default {@link NoopTracer} is used.
+ *
+ * <p>
+ * Where possible, use some form of dependency injection (of which there are
+ * many) to access the `Tracer` instance. For vanilla application code, this is
+ * often reasonable and cleaner for all of the usual DI reasons.
+ *
+ * <p>
+ * That said, instrumentation for packages that are themselves statically
+ * configured (e.g., JDBC drivers) may be unable to make use of said DI
+ * mechanisms for {@link Tracer} access, and as such they should fall back on
+ * {@link GlobalTracer}. By and large, OpenTracing instrumentation should
+ * always allow the programmer to specify a {@link Tracer} instance to use for
+ * instrumentation, though the {@link GlobalTracer} is a reasonable fallback or
+ * default value.
+ */
+public final class GlobalTracer implements Tracer {
+    private static final Logger LOGGER = Logger.getLogger(GlobalTracer.class.getName());
+
+    /**
+     * Singleton instance.
+     * <p>
+     * Since we cannot prevent people using {@linkplain #get() GlobalTracer.get()} as a constant,
+     * this guarantees that references obtained before, during or after initialization
+     * all behave as if obtained <em>after</em> initialization once properly initialized.<br>
+     * As a minor additional benefit it makes it harder to circumvent the {@link Tracer} API.
+     */
+    private static final GlobalTracer INSTANCE = new GlobalTracer();
+
+    /**
+     * The registered {@link Tracer} delegate or the {@link NoopTracer} if none was registered yet.
+     * Never {@code null}.
+     */
+    private static volatile Tracer tracer = NoopTracerFactory.create();
+
+    private GlobalTracer() {
+    }
+
+    /**
+     * Returns the constant {@linkplain GlobalTracer}.
+     * <p>
+     * All methods are forwarded to the currently configured tracer.<br>
+     * Until a tracer is {@link #register(Tracer) explicitly configured},
+     * the {@link io.opentracing.noop.NoopTracer NoopTracer} is used.
+     *
+     * @return The global tracer constant.
+     * @see #register(Tracer)
+     */
+    public static Tracer get() {
+        return INSTANCE;
+    }
+
+    /**
+     * Register a {@link Tracer} to back the behaviour of the {@link #get() global tracer}.
+     * <p>
+     * Registration is a one-time operation, attempting to call it more often will result in a runtime exception.
+     * <p>
+     * Every application intending to use the global tracer is responsible for registering it once
+     * during its initialization.
+     *
+     * @param tracer Tracer to use as global tracer.
+     * @throws RuntimeException if there is already a current tracer registered
+     */
+    public static synchronized void register(final Tracer tracer) {
+        if (tracer == null) {
+            throw new NullPointerException("Cannot register GlobalTracer <null>.");
+        }
+        if (tracer instanceof GlobalTracer) {
+            LOGGER.log(Level.FINE, "Attempted to register the GlobalTracer as delegate of itself.");
+            return; // no-op
+        }
+        if (isRegistered() && !GlobalTracer.tracer.equals(tracer)) {
+            throw new IllegalStateException("There is already a current global Tracer registered.");
+        }
+        GlobalTracer.tracer = tracer;
+    }
+
+    /**
+     * Identify whether a {@link Tracer} has previously been registered.
+     * <p>
+     * This check is useful in scenarios where more than one component may be responsible
+     * for registering a tracer. For example, when using a Java Agent, it will need to determine
+     * if the application has already registered a tracer, and if not attempt to resolve and
+     * register one itself.
+     *
+     * @return Whether a tracer has been registered
+     */
+    public static synchronized boolean isRegistered() {
+        return !(GlobalTracer.tracer instanceof NoopTracer);
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) {
+        return tracer.buildSpan(operationName);
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+        tracer.inject(spanContext, format, carrier);
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        return tracer.extract(format, carrier);
+    }
+
+    @Override
+    public String toString() {
+        return GlobalTracer.class.getSimpleName() + '{' + tracer + '}';
+    }
+
+    @Override
+    public ActiveSpan activeSpan() {
+        return tracer.activeSpan();
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        return tracer.makeActive(span);
+    }
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/util/ThreadLocalActiveSpan.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/util/ThreadLocalActiveSpan.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.util;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.ActiveSpanSource;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+
+/**
+ * {@link ThreadLocalActiveSpan} is a simple {@link ActiveSpan} implementation that relies on Java's
+ * thread-local storage primitive.
+ *
+ * @see ActiveSpanSource
+ * @see Tracer#activeSpan()
+ */
+public class ThreadLocalActiveSpan implements ActiveSpan {
+    private final ThreadLocalActiveSpanSource source;
+    private final Span wrapped;
+    private final ThreadLocalActiveSpan toRestore;
+    private final AtomicInteger refCount;
+
+    ThreadLocalActiveSpan(ThreadLocalActiveSpanSource source, Span wrapped, AtomicInteger refCount) {
+        this.source = source;
+        this.refCount = refCount;
+        this.wrapped = wrapped;
+        this.toRestore = source.tlsSnapshot.get();
+        source.tlsSnapshot.set(this);
+    }
+
+    @Override
+    public void deactivate() {
+        if (source.tlsSnapshot.get() != this) {
+            // This shouldn't happen if users call methods in the expected order. Bail out.
+            return;
+        }
+        source.tlsSnapshot.set(toRestore);
+
+        if (0 == refCount.decrementAndGet()) {
+            wrapped.finish();
+        }
+    }
+
+    @Override
+    public Continuation capture() {
+        return new ThreadLocalActiveSpan.Continuation();
+    }
+
+    @Override
+    public SpanContext context() {
+        return wrapped.context();
+    }
+
+    @Override
+    public ThreadLocalActiveSpan setTag(String key, String value) {
+        wrapped.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan setTag(String key, boolean value) {
+        wrapped.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan setTag(String key, Number value) {
+        wrapped.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan log(Map<String, ?> fields) {
+        wrapped.log(fields);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan log(long timestampMicroseconds, Map<String, ?> fields) {
+        wrapped.log(timestampMicroseconds, fields);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan log(String event) {
+        wrapped.log(event);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan log(long timestampMicroseconds, String event) {
+        wrapped.log(timestampMicroseconds, event);
+        return this;
+    }
+
+    @Override
+    public ThreadLocalActiveSpan setBaggageItem(String key, String value) {
+        wrapped.setBaggageItem(key, value);
+        return this;
+    }
+
+    @Override
+    public String getBaggageItem(String key) {
+        return wrapped.getBaggageItem(key);
+    }
+
+    @Override
+    public ThreadLocalActiveSpan setOperationName(String operationName) {
+        wrapped.setOperationName(operationName);
+        return this;
+    }
+
+    @Override
+    public void close() {
+        deactivate();
+    }
+
+    @Override
+    public String toString() {
+        return wrapped.toString();
+    }
+
+    private final class Continuation implements ActiveSpan.Continuation {
+        Continuation() {
+            refCount.incrementAndGet();
+        }
+
+        @Override
+        public ThreadLocalActiveSpan activate() {
+            return new ThreadLocalActiveSpan(source, wrapped, refCount);
+        }
+    }
+
+}

--- a/opentracing-v030/src/main/java/io/opentracing/v_030/util/ThreadLocalActiveSpanSource.java
+++ b/opentracing-v030/src/main/java/io/opentracing/v_030/util/ThreadLocalActiveSpanSource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.util;
+
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.ActiveSpanSource;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.Tracer;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A simple {@link ActiveSpanSource} implementation built on top of Java's thread-local storage primitive.
+ *
+ * @see ThreadLocalActiveSpan
+ * @see Tracer#activeSpan()
+ */
+public class ThreadLocalActiveSpanSource implements ActiveSpanSource {
+    final ThreadLocal<ThreadLocalActiveSpan> tlsSnapshot = new ThreadLocal<ThreadLocalActiveSpan>();
+
+    @Override
+    public ThreadLocalActiveSpan activeSpan() {
+        return tlsSnapshot.get();
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        return new ThreadLocalActiveSpan(this, span, new AtomicInteger(1));
+    }
+
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/AssertionTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/AssertionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030;
+
+import org.junit.Test;
+
+public final class AssertionTest {
+
+    @Test
+    public void test_assertions_enabled() {
+        boolean asserted = false;
+        try {
+            assert false;
+        } catch (AssertionError error) {
+            asserted = true;
+        }
+        if (!asserted) {
+            throw new AssertionError("assertions are not enabled");
+        }
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/mock/MockSpanTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/mock/MockSpanTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.mock;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.opentracing.v_030.Span;
+
+/**
+ * @author Pavol Loffay
+ */
+public class MockSpanTest {
+
+    @Test
+    public void testSetOperationNameAfterFinish() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").start();
+        span.finish();
+
+        try {
+            span.setOperationName("bar");
+            Assert.fail();
+        } catch (RuntimeException ex) {
+        }
+        Assert.assertEquals(1, tracer.finishedSpans().get(0).generatedErrors().size());
+    }
+
+    @Test
+    public void testSetTagAfterFinish() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").start();
+        span.finish();
+
+        try {
+            span.setTag("bar", "foo");
+            Assert.fail();
+        } catch (RuntimeException ex) {
+        }
+        Assert.assertEquals(1, tracer.finishedSpans().get(0).generatedErrors().size());
+    }
+
+    @Test
+    public void testAddLogAfterFinish() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").start();
+        span.finish();
+
+        try {
+            span.log("bar");
+            Assert.fail();
+        } catch (RuntimeException ex) {
+        }
+        Assert.assertEquals(1, tracer.finishedSpans().get(0).generatedErrors().size());
+    }
+
+    @Test
+    public void testAddBaggageAfterFinish() {
+        MockTracer tracer = new MockTracer();
+        Span span = tracer.buildSpan("foo").start();
+        span.finish();
+
+        try {
+            span.setBaggageItem("foo", "bar");
+            Assert.fail();
+        } catch (RuntimeException ex) {
+        }
+        Assert.assertEquals(1, tracer.finishedSpans().get(0).generatedErrors().size());
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/mock/MockTracerTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/mock/MockTracerTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.propagation.Format;
+import io.opentracing.v_030.propagation.TextMapExtractAdapter;
+import io.opentracing.v_030.propagation.TextMapInjectAdapter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MockTracerTest {
+    @Test
+    public void testRootSpan() {
+        // Create and finish a root Span.
+        MockTracer tracer = new MockTracer();
+        {
+            Span span = tracer.buildSpan("tester").withStartTimestamp(1000).start();
+            span.setTag("string", "foo");
+            span.setTag("int", 7);
+            span.log("foo");
+            Map<String, Object> fields = new HashMap<>();
+            fields.put("f1", 4);
+            fields.put("f2", "two");
+            span.log(1002, fields);
+            span.log(1003, "event name");
+            span.finish(2000);
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        // Check that the Span looks right.
+        assertEquals(1, finishedSpans.size());
+        MockSpan finishedSpan = finishedSpans.get(0);
+        assertEquals("tester", finishedSpan.operationName());
+        assertEquals(0, finishedSpan.parentId());
+        assertNotEquals(0, finishedSpan.context().traceId());
+        assertNotEquals(0, finishedSpan.context().spanId());
+        assertEquals(1000, finishedSpan.startMicros());
+        assertEquals(2000, finishedSpan.finishMicros());
+        Map<String, Object> tags = finishedSpan.tags();
+        assertEquals(2, tags.size());
+        assertEquals(7, tags.get("int"));
+        assertEquals("foo", tags.get("string"));
+        List<MockSpan.LogEntry> logs = finishedSpan.logEntries();
+        assertEquals(3, logs.size());
+        {
+            MockSpan.LogEntry log = logs.get(0);
+            assertEquals(1, log.fields().size());
+            assertEquals("foo", log.fields().get("event"));
+        }
+        {
+            MockSpan.LogEntry log = logs.get(1);
+            assertEquals(1002, log.timestampMicros());
+            assertEquals(4, log.fields().get("f1"));
+            assertEquals("two", log.fields().get("f2"));
+        }
+        {
+            MockSpan.LogEntry log = logs.get(2);
+            assertEquals(1003, log.timestampMicros());
+            assertEquals("event name", log.fields().get("event"));
+        }
+    }
+
+    @Test
+    public void testChildSpan() {
+        // Create and finish a root Span.
+        MockTracer tracer = new MockTracer();
+        {
+            Span parent = tracer.buildSpan("parent").withStartTimestamp(1000).start();
+            Span child = tracer.buildSpan("child").withStartTimestamp(1100).asChildOf(parent).start();
+            child.finish(1900);
+            parent.finish(2000);
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        // Check that the Spans look right.
+        assertEquals(2, finishedSpans.size());
+        MockSpan child = finishedSpans.get(0);
+        MockSpan parent = finishedSpans.get(1);
+        assertEquals("child", child.operationName());
+        assertEquals("parent", parent.operationName());
+        assertEquals(parent.context().spanId(), child.parentId());
+        assertEquals(parent.context().traceId(), child.context().traceId());
+
+    }
+
+    @Test
+    public void testStartTimestamp() throws InterruptedException {
+        MockTracer tracer = new MockTracer();
+        long startMicros;
+        {
+            Tracer.SpanBuilder fooSpan = tracer.buildSpan("foo");
+            Thread.sleep(2);
+            startMicros = System.currentTimeMillis() * 1000;
+            fooSpan.start().finish();
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        Assert.assertEquals(1, finishedSpans.size());
+        MockSpan span = finishedSpans.get(0);
+        Assert.assertTrue(startMicros <= span.startMicros());
+        Assert.assertTrue(System.currentTimeMillis() * 1000 >= span.finishMicros());
+    }
+
+    @Test
+    public void testStartExplicitTimestamp() throws InterruptedException {
+        MockTracer tracer = new MockTracer();
+        long startMicros = 2000;
+        {
+            tracer.buildSpan("foo")
+                    .withStartTimestamp(startMicros)
+                    .start()
+                    .finish();
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        Assert.assertEquals(1, finishedSpans.size());
+        Assert.assertEquals(startMicros, finishedSpans.get(0).startMicros());
+    }
+
+    @Test
+    public void testTextMapPropagatorTextMap() {
+        MockTracer tracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
+        HashMap<String, String> injectMap = new HashMap<>();
+        injectMap.put("foobag", "donttouch");
+        {
+            Span parentSpan = tracer.buildSpan("foo")
+                    .start();
+            parentSpan.setBaggageItem("foobag", "fooitem");
+            parentSpan.finish();
+
+            tracer.inject(parentSpan.context(), Format.Builtin.TEXT_MAP,
+                    new TextMapInjectAdapter(injectMap));
+
+            SpanContext extract = tracer.extract(Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(injectMap));
+
+            Span childSpan = tracer.buildSpan("bar")
+                    .asChildOf(extract)
+                    .start();
+            childSpan.setBaggageItem("barbag", "baritem");
+            childSpan.finish();
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        Assert.assertEquals(2, finishedSpans.size());
+        Assert.assertEquals(finishedSpans.get(0).context().traceId(), finishedSpans.get(1).context().traceId());
+        Assert.assertEquals(finishedSpans.get(0).context().spanId(), finishedSpans.get(1).parentId());
+        Assert.assertEquals("fooitem", finishedSpans.get(0).getBaggageItem("foobag"));
+        Assert.assertNull(finishedSpans.get(0).getBaggageItem("barbag"));
+        Assert.assertEquals("fooitem", finishedSpans.get(1).getBaggageItem("foobag"));
+        Assert.assertEquals("baritem", finishedSpans.get(1).getBaggageItem("barbag"));
+        Assert.assertEquals("donttouch", injectMap.get("foobag"));
+    }
+
+    @Test
+    public void testTextMapPropagatorHttpHeaders() {
+        MockTracer tracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
+        {
+            Span parentSpan = tracer.buildSpan("foo")
+                    .start();
+            parentSpan.finish();
+
+            HashMap<String, String> injectMap = new HashMap<>();
+            tracer.inject(parentSpan.context(), Format.Builtin.HTTP_HEADERS,
+                    new TextMapInjectAdapter(injectMap));
+
+            SpanContext extract = tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapExtractAdapter(injectMap));
+
+            tracer.buildSpan("bar")
+                    .asChildOf(extract)
+                    .start()
+                    .finish();
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        Assert.assertEquals(2, finishedSpans.size());
+        Assert.assertEquals(finishedSpans.get(0).context().traceId(), finishedSpans.get(1).context().traceId());
+        Assert.assertEquals(finishedSpans.get(0).context().spanId(), finishedSpans.get(1).parentId());
+    }
+
+    @Test
+    public void testReset() {
+        MockTracer mockTracer = new MockTracer();
+
+        mockTracer.buildSpan("foo")
+            .startManual()
+            .finish();
+
+        assertEquals(1, mockTracer.finishedSpans().size());
+        mockTracer.reset();
+        assertEquals(0, mockTracer.finishedSpans().size());
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/propagation/BuiltinFormatTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/propagation/BuiltinFormatTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.propagation;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BuiltinFormatTest {
+
+    @Test
+    public void test_HTTP_HEADERS_toString() {
+        assertEquals("Builtin.HTTP_HEADERS", Format.Builtin.HTTP_HEADERS.toString());
+    }
+
+    @Test
+    public void test_TEXT_MAP_toString() {
+        assertEquals("Builtin.TEXT_MAP", Format.Builtin.TEXT_MAP.toString());
+    }
+
+    @Test
+    public void test_BINARY_toString() {
+        assertEquals("Builtin.BINARY", Format.Builtin.BINARY.toString());
+    }
+
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/propagation/TextMapExtractAdapterTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/propagation/TextMapExtractAdapterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.propagation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.junit.Test;
+
+/**
+ * @author Pavol Loffay
+ */
+public class TextMapExtractAdapterTest {
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testPut() {
+        Map<String, String> headers = new LinkedHashMap<String, String>();
+        TextMapExtractAdapter injectAdapter = new TextMapExtractAdapter(headers);
+        injectAdapter.put("foo", "bar");
+    }
+
+    @Test
+    public void testIterator() {
+        Map<String, String> headers = new LinkedHashMap<String, String>();
+        headers.put("foo", "bar");
+        TextMapExtractAdapter extractAdapter = new TextMapExtractAdapter(headers);
+
+        Iterator<Entry<String, String>> iterator = extractAdapter.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals("bar", iterator.next().getValue());
+        assertFalse(iterator.hasNext());
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/propagation/TextMapInjectAdapterTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/propagation/TextMapInjectAdapterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.propagation;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * @author Pavol Loffay
+ */
+public class TextMapInjectAdapterTest {
+
+    @Test
+    public void testPut() {
+        Map<String, String> headers = new LinkedHashMap<String, String>();
+        TextMapInjectAdapter injectAdapter = new TextMapInjectAdapter(headers);
+        injectAdapter.put("foo", "bar");
+
+        assertEquals("bar", headers.get("foo"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testIterator() {
+        Map<String, String> headers = new LinkedHashMap<String, String>();
+        TextMapInjectAdapter injectAdapter = new TextMapInjectAdapter(headers);
+        injectAdapter.iterator();
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/shim/ActiveSpanShimTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/shim/ActiveSpanShimTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import org.junit.Before;
+import org.junit.Test;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockTracer.Propagator;
+import io.opentracing.util.AutoFinishScopeManager;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.shim.TracerShim;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class ActiveSpanShimTest {
+    private final MockTracer mockTracer = new MockTracer(new AutoFinishScopeManager(),
+            Propagator.TEXT_MAP);
+    private Tracer shim;
+
+    @Before
+    public void before() {
+        mockTracer.reset();
+        shim = new TracerShim(mockTracer);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void capture() {
+        shim.buildSpan("one").startActive().capture();
+    }
+
+    @Test
+    public void log() {
+        shim.buildSpan("one").startActive()
+            .log("myEvent")
+            .close();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        List<MockSpan.LogEntry> logs = finishedSpans.get(0).logEntries();
+        assertEquals(1, logs.size());
+        assertEquals(1, logs.get(0).fields().size());
+        assertEquals("myEvent", logs.get(0).fields().get("event"));
+    }
+
+    @Test
+    public void setBaggageItem() {
+        shim.buildSpan("one").startActive()
+            .setBaggageItem("foobag", "foovalue")
+            .close();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+        assertEquals("foovalue", finishedSpans.get(0).getBaggageItem("foobag"));
+    }
+
+    @Test
+    public void setOperationName() {
+        shim.buildSpan("one").startActive()
+            .setOperationName("1")
+            .close();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+        assertEquals("1", finishedSpans.get(0).operationName());
+    }
+
+    @Test
+    public void setTag() {
+        shim.buildSpan("one").startActive()
+            .setTag("string", "string")
+            .setTag("boolean", true)
+            .setTag("number", 13)
+            .close();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals("string", tags.get("string"));
+        assertEquals(true, tags.get("boolean"));
+        assertEquals(13, tags.get("number"));
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/shim/ActiveSpanShimTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/shim/ActiveSpanShimTest.java
@@ -44,11 +44,6 @@ public class ActiveSpanShimTest {
         shim = new TracerShim(mockTracer);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void capture() {
-        shim.buildSpan("one").startActive().capture();
-    }
-
     @Test
     public void log() {
         shim.buildSpan("one").startActive()

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/shim/ActiveSpanShimTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/shim/ActiveSpanShimTest.java
@@ -24,6 +24,7 @@ import io.opentracing.v_030.Span;
 import io.opentracing.v_030.SpanContext;
 import io.opentracing.v_030.Tracer;
 import io.opentracing.v_030.shim.TracerShim;
+import io.opentracing.v_030.tag.Tags;
 
 import java.util.List;
 import java.util.Map;
@@ -97,4 +98,18 @@ public class ActiveSpanShimTest {
         assertEquals(true, tags.get("boolean"));
         assertEquals(13, tags.get("number"));
     }
+
+    @Test
+    public void setTagIndirectly() {
+        ActiveSpan span = shim.buildSpan("one").startActive();
+        Tags.COMPONENT.set(span, "shim");
+        span.close();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals("shim", tags.get(Tags.COMPONENT.getKey()));
+    }
+
 }

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/shim/BaseTracerShimTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/shim/BaseTracerShimTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import org.junit.Before;
+import org.junit.Test;
+import io.opentracing.Scope;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockTracer.Propagator;
+import io.opentracing.util.ThreadLocalScopeManager;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.References;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.propagation.Format;
+import io.opentracing.v_030.propagation.TextMapExtractAdapter;
+import io.opentracing.v_030.propagation.TextMapInjectAdapter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public final class BaseTracerShimTest {
+    private final MockTracer mockTracer = new MockTracer(new ThreadLocalScopeManager(),
+            Propagator.TEXT_MAP);
+    private Tracer shim;
+
+    final static class TestTracerShim extends BaseTracerShim {
+        public TestTracerShim(io.opentracing.Tracer tracer) {
+            super(tracer);
+        }
+    }
+
+    @Before
+    public void before() {
+        mockTracer.reset();
+        shim = new TestTracerShim(mockTracer);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void ctorNullTracer() {
+        new TestTracerShim(null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void spanCapture() {
+        shim.buildSpan("one").startActive().capture();
+    }
+
+    @Test
+    public void activeSpan() {
+        ActiveSpan span = null;
+        try {
+            span = shim.buildSpan("one").startActive();
+            assertNotNull(span);
+            assertNotNull(shim.activeSpan());
+            assertEquals(0, mockTracer.finishedSpans().size());
+        } finally {
+            span.deactivate();
+        }
+
+        assertNull(shim.activeSpan());
+        assertEquals(1, mockTracer.finishedSpans().size());
+        assertEquals("one", mockTracer.finishedSpans().get(0).operationName());
+    }
+
+    @Test
+    public void activeSpanOnTheSide() {
+        Scope scope = null;
+        try {
+            scope = mockTracer.buildSpan("one").startActive();
+            assertNotNull(shim.activeSpan());
+        } finally {
+            scope.close();
+        }
+
+        assertNull(shim.activeSpan());
+    }
+
+    @Test
+    public void activeSpanNone() {
+        assertNull(shim.activeSpan());
+
+        Span span = shim.buildSpan("one").startManual();
+        assertNull(shim.activeSpan());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void makeActiveNull() {
+        shim.makeActive(null);
+    }
+
+    @Test
+    public void makeActive() {
+        Span span = shim.buildSpan("one").startManual();
+        ActiveSpan active = null;
+        try {
+            active = shim.makeActive(span);
+            assertNotNull(active);
+            assertNotNull(shim.activeSpan());
+            assertEquals(0, mockTracer.finishedSpans().size());
+        } finally {
+            active.deactivate();
+        }
+
+        assertNull(shim.activeSpan());
+        assertEquals(1, mockTracer.finishedSpans().size());
+    }
+
+    @Test
+    public void injectExtractTextMap() {
+        Map<String, String> injectMap = new HashMap<String, String>();
+
+        Span span = shim.buildSpan("parent").startManual();
+        span.finish();
+        shim.inject(span.context(), Format.Builtin.TEXT_MAP, new TextMapInjectAdapter(injectMap));
+
+        SpanContext extract = shim.extract(Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(injectMap));
+        shim.buildSpan("child").asChildOf(extract).startManual().finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(2, finishedSpans.size());
+        assertEquals(finishedSpans.get(0).context().traceId(), finishedSpans.get(1).context().traceId());
+    }
+
+    @Test
+    public void injectExtractHttp() {
+        Map<String, String> injectMap = new HashMap<String, String>();
+
+        Span span = shim.buildSpan("parent").startManual();
+        span.finish();
+        shim.inject(span.context(), Format.Builtin.HTTP_HEADERS, new TextMapInjectAdapter(injectMap));
+
+        SpanContext extract = shim.extract(Format.Builtin.HTTP_HEADERS, new TextMapExtractAdapter(injectMap));
+        shim.buildSpan("child").asChildOf(extract).startManual().finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(2, finishedSpans.size());
+        assertEquals(finishedSpans.get(0).context().traceId(), finishedSpans.get(1).context().traceId());
+    }
+
+    @Test
+    public void builderAsChildOfSpan() {
+        Span parentSpan = shim.buildSpan("parent").startManual();
+        Span childSpan = shim.buildSpan("child").asChildOf(parentSpan).startManual();
+        childSpan.finish();
+        parentSpan.finish();
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(2, spans.size());
+        assertEquals("child", spans.get(0).operationName());
+        assertEquals("parent", spans.get(1).operationName());
+        assertEquals(spans.get(0).parentId(), spans.get(1).context().spanId());
+    }
+
+    @Test
+    public void builderAsChildOfActiveSpan() {
+        ActiveSpan parentSpan, childSpan, childSpan2;
+        parentSpan = childSpan = childSpan2 = null;
+        try {
+            parentSpan = shim.buildSpan("parent").startActive();
+            try {
+                childSpan = shim.buildSpan("child").startActive();
+                try {
+                    childSpan2 = shim.buildSpan("child2").asChildOf(parentSpan).startActive();
+                } finally {
+                    childSpan2.deactivate();
+                }
+            } finally {
+                childSpan.deactivate();
+            }
+        } finally {
+            parentSpan.deactivate();
+        }
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(3, spans.size());
+        assertEquals("child2", spans.get(0).operationName());
+        assertEquals("child", spans.get(1).operationName());
+        assertEquals("parent", spans.get(2).operationName());
+        assertEquals(spans.get(0).parentId(), spans.get(2).context().spanId());
+    }
+
+    @Test
+    public void builderAsChildOfContext() {
+        Span parentSpan = shim.buildSpan("parent").startManual();
+        Span childSpan = shim.buildSpan("child").asChildOf(parentSpan.context()).startManual();
+        childSpan.finish();
+        parentSpan.finish();
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(2, spans.size());
+        assertEquals("child", spans.get(0).operationName());
+        assertEquals("parent", spans.get(1).operationName());
+        assertEquals(spans.get(0).parentId(), spans.get(1).context().spanId());
+    }
+
+    @Test
+    public void builderIgnoreActiveSpan() {
+        ActiveSpan parentSpan, childSpan;
+        parentSpan = childSpan = null;
+        try {
+            parentSpan = shim.buildSpan("one").startActive();
+            try {
+                childSpan = shim.buildSpan("two").ignoreActiveSpan().startActive();
+            } finally {
+                childSpan.deactivate();
+            }
+        } finally {
+            parentSpan.deactivate();
+        }
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(2, spans.size());
+        assertEquals("two", spans.get(0).operationName());
+        assertEquals("one", spans.get(1).operationName());
+        assertNotEquals(spans.get(0).context().traceId(), spans.get(1).context().traceId());
+    }
+
+    @Test
+    public void builderAddReference() {
+        Span parentSpan = shim.buildSpan("parent").startManual();
+        Span childSpan = shim.buildSpan("child").addReference(References.CHILD_OF, parentSpan.context()).startManual();
+        childSpan.finish();
+        parentSpan.finish();
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(2, spans.size());
+        assertEquals("child", spans.get(0).operationName());
+        assertEquals("parent", spans.get(1).operationName());
+        assertEquals(spans.get(0).parentId(), spans.get(1).context().spanId());
+    }
+
+    @Test
+    public void builderWithTag() {
+        shim.buildSpan("one")
+            .withTag("string", "string")
+            .withTag("boolean", true)
+            .withTag("number", 13)
+            .startManual()
+            .finish();
+
+        assertEquals(1, mockTracer.finishedSpans().size());
+        
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals("string", tags.get("string"));
+        assertEquals(true, tags.get("boolean"));
+        assertEquals(13, tags.get("number"));
+    }
+
+    @Test
+    public void builderWithStartTimestamp() {
+        shim.buildSpan("one")
+            .withStartTimestamp(113)
+            .startManual()
+            .finish();
+
+        assertEquals(1, mockTracer.finishedSpans().size());
+        assertEquals(113, mockTracer.finishedSpans().get(0).startMicros());
+    }
+
+    @Test
+    public void builderStart() {
+        shim.buildSpan("one").start().finish();
+
+        assertEquals(1, mockTracer.finishedSpans().size());
+        assertEquals("one", mockTracer.finishedSpans().get(0).operationName());
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/shim/SpanShimTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/shim/SpanShimTest.java
@@ -23,6 +23,7 @@ import io.opentracing.v_030.Span;
 import io.opentracing.v_030.SpanContext;
 import io.opentracing.v_030.Tracer;
 import io.opentracing.v_030.shim.TracerShim;
+import io.opentracing.v_030.tag.Tags;
 
 import java.util.List;
 import java.util.Map;
@@ -105,5 +106,18 @@ public class SpanShimTest {
         assertEquals("string", tags.get("string"));
         assertEquals(true, tags.get("boolean"));
         assertEquals(13, tags.get("number"));
+    }
+
+    @Test
+    public void setTagIndirectly() {
+        Span span = shim.buildSpan("one").startManual();
+        Tags.COMPONENT.set(span, "shim");
+        span.finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals("shim", tags.get(Tags.COMPONENT.getKey()));
     }
 }

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/shim/SpanShimTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/shim/SpanShimTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import org.junit.Before;
+import org.junit.Test;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockTracer.Propagator;
+import io.opentracing.util.AutoFinishScopeManager;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.shim.TracerShim;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class SpanShimTest {
+    private final MockTracer mockTracer = new MockTracer(new AutoFinishScopeManager(),
+            Propagator.TEXT_MAP);
+    private Tracer shim;
+
+    @Before
+    public void before() {
+        mockTracer.reset();
+        shim = new TracerShim(mockTracer);
+    }
+
+    @Test
+    public void finishMicros() {
+        shim.buildSpan("one").startManual()
+            .finish(10100);
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+        assertEquals(10100, finishedSpans.get(0).finishMicros());
+    }
+
+    @Test
+    public void log() {
+        shim.buildSpan("one").startManual()
+            .log("myEvent")
+            .finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        List<MockSpan.LogEntry> logs = finishedSpans.get(0).logEntries();
+        assertEquals(1, logs.size());
+        assertEquals(1, logs.get(0).fields().size());
+        assertEquals("myEvent", logs.get(0).fields().get("event"));
+    }
+
+    @Test
+    public void setBaggageItem() {
+        shim.buildSpan("one").startManual()
+            .setBaggageItem("foobag", "foovalue")
+            .finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+        assertEquals("foovalue", finishedSpans.get(0).getBaggageItem("foobag"));
+    }
+
+    @Test
+    public void setOperationName() {
+        shim.buildSpan("one").startManual()
+            .setOperationName("1")
+            .finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+        assertEquals("1", finishedSpans.get(0).operationName());
+    }
+
+    @Test
+    public void setTag() {
+        shim.buildSpan("one").startManual()
+            .setTag("string", "string")
+            .setTag("boolean", true)
+            .setTag("number", 13)
+            .finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals("string", tags.get("string"));
+        assertEquals(true, tags.get("boolean"));
+        assertEquals(13, tags.get("number"));
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/shim/TracerShimTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/shim/TracerShimTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import org.junit.Before;
+import org.junit.Test;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockTracer.Propagator;
+import io.opentracing.util.AutoFinishScopeManager;
+import io.opentracing.util.ThreadLocalScopeManager;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public final class TracerShimTest {
+    private final MockTracer mockTracer = new MockTracer(new AutoFinishScopeManager(),
+            Propagator.TEXT_MAP);
+    private Tracer shim;
+
+    @Before
+    public void before() {
+        mockTracer.reset();
+        shim = new TracerShim(mockTracer);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void ctorNullTracer() {
+        new TracerShim(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void ctorUnsupportedScopeManager() {
+        MockTracer tracer = new MockTracer(new ThreadLocalScopeManager(),
+                Propagator.TEXT_MAP);
+        new TracerShim(tracer);
+    }
+
+    @Test
+    public void simpleSpan() {
+        ActiveSpan span = null;
+        try {
+            span = shim.buildSpan("one").startActive();
+            assertNotNull(span);
+            assertNotNull(shim.activeSpan());
+            assertEquals(0, mockTracer.finishedSpans().size());
+        } finally {
+            span.deactivate();
+        }
+
+        assertNull(shim.activeSpan());
+        assertEquals(1, mockTracer.finishedSpans().size());
+    }
+
+    @Test
+    public void captureSpan() {
+        int captureCount = 3;
+        ActiveSpan.Continuation continuations[] = new ActiveSpan.Continuation[captureCount];
+
+        ActiveSpan span = null;
+        try {
+            span = shim.buildSpan("one").startActive();
+            assertNotNull(shim.activeSpan());
+            assertEquals(0, mockTracer.finishedSpans().size());
+
+            for (int i = 0; i < captureCount; i++) {
+                ActiveSpan.Continuation cont = span.capture();
+                continuations[i] = cont;
+                assertNotNull(cont);
+            }
+        } finally {
+            span.deactivate();
+        }
+
+        for (int i = 0; i < captureCount; i++) {
+            assertNull(shim.activeSpan());
+            assertEquals(0, mockTracer.finishedSpans().size());
+
+            try {
+                continuations[i].activate();
+                assertNotNull(shim.activeSpan());
+                shim.activeSpan().setTag(Integer.toString(i), "value");
+
+            } finally {
+                shim.activeSpan().deactivate();
+            }
+        }
+
+        assertNull(shim.activeSpan());
+        assertEquals(1, mockTracer.finishedSpans().size());
+
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals(captureCount, tags.size());
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/tag/AbstractTagTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/tag/AbstractTagTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.tag;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.opentracing.v_030.Span;
+import org.junit.Test;
+
+/**
+ * @author Pavol Loffay
+ */
+public class AbstractTagTest {
+
+    @Test
+    public void testGetKey() {
+        String key = "bar";
+        StringTag tag = new StringTag(key);
+        assertEquals(key, tag.getKey());
+    }
+
+    @Test
+    public void testSetTagOnSpan() {
+        String value = "foo";
+        String key = "bar";
+
+        Span activeSpan = mock(Span.class);
+        StringTag tag = new StringTag(key);
+        tag.set(activeSpan, value);
+
+        verify(activeSpan).setTag(key, value);
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/tag/BooleanTagTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/tag/BooleanTagTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.tag;
+
+import io.opentracing.v_030.Span;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class BooleanTagTest {
+    @Test
+    public void testSetBoolean() {
+        Boolean value = true;
+        String key = "expected.key";
+        Span span = mock(Span.class);
+
+        BooleanTag tag = new BooleanTag(key);
+        tag.set(span, value);
+
+        verify(span).setTag(key, value);
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/tag/IntTagTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/tag/IntTagTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.tag;
+
+import io.opentracing.v_030.Span;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class IntTagTest {
+    @Test
+    public void testSetInt() {
+        Integer value = 7;
+        String key = "expected.key";
+        Span span = mock(Span.class);
+
+        IntTag tag = new IntTag(key);
+        tag.set(span, value);
+
+        verify(span).setTag(key, value);
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/tag/StringTagTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/tag/StringTagTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.tag;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.opentracing.v_030.Span;
+import org.junit.Test;
+
+public class StringTagTest {
+
+    @Test
+    public void testSetString() {
+        String value = "expected.value";
+        String key = "expected.key";
+
+        Span span = mock(Span.class);
+        StringTag tag = new StringTag(key);
+        tag.set(span, value);
+
+        verify(span).setTag(key, value);
+    }
+
+    @Test
+    public void testSetOtherTag() {
+        String key = "expected.key";
+
+        Span span = mock(Span.class);
+        StringTag tag = new StringTag(key);
+        tag.set(span, new StringTag(key));
+
+        verify(span).setTag(key, key);
+    }
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/util/GlobalTracerTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/util/GlobalTracerTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.util;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.noop.NoopSpanBuilder;
+import io.opentracing.v_030.noop.NoopTracerFactory;
+import io.opentracing.v_030.propagation.Format;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GlobalTracerTest {
+
+    private static void _setGlobal(Tracer tracer) {
+        try {
+            Field globalTracerField = GlobalTracer.class.getDeclaredField("tracer");
+            globalTracerField.setAccessible(true);
+            globalTracerField.set(null, tracer);
+            globalTracerField.setAccessible(false);
+        } catch (Exception e) {
+            throw new RuntimeException("Error reflecting globalTracer: " + e.getMessage(), e);
+        }
+    }
+
+    @Before
+    @After
+    public void clearGlobalTracer() {
+        _setGlobal(NoopTracerFactory.create());
+    }
+
+    @Test
+    public void testGet_SingletonReference() {
+        Tracer tracer = GlobalTracer.get();
+        assertThat(tracer, is(instanceOf(GlobalTracer.class)));
+        assertThat(tracer, is(sameInstance(GlobalTracer.get())));
+    }
+
+    @Test
+    public void testMultipleRegistrations() {
+        GlobalTracer.register(mock(Tracer.class));
+        try {
+            GlobalTracer.register(mock(Tracer.class));
+            fail("Duplicate registration exception expected.");
+        } catch (RuntimeException expected) {
+            assertThat("Duplicate registration message", expected.getMessage(), is(notNullValue()));
+        }
+    }
+
+    /**
+     * Check leniency for duplicate registration with the same tracer by mistake.
+     */
+    @Test
+    public void testMultipleRegistrations_sameTracer() {
+        Tracer mockTracer = mock(Tracer.class);
+        GlobalTracer.register(mockTracer);
+        GlobalTracer.register(mockTracer);
+        // 'test' that double registration of the same tracer does not throw exception
+    }
+
+    @Test
+    public void testRegisterGlobalTracer() {
+        assertThat(GlobalTracer.get().buildSpan("foo"), is(instanceOf(NoopSpanBuilder.class)));
+        GlobalTracer.register(GlobalTracer.get());
+        assertThat(GlobalTracer.get().buildSpan("foo"), is(instanceOf(NoopSpanBuilder.class)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testRegisterNull() {
+        GlobalTracer.register(null);
+    }
+
+    @Test
+    public void testNoopTracerByDefault() {
+        Tracer.SpanBuilder spanBuilder = GlobalTracer.get().buildSpan("my-operation");
+        assertThat(spanBuilder, is(instanceOf(NoopSpanBuilder.class)));
+    }
+
+    @Test
+    public void testDelegation_buildSpan() {
+        Tracer mockTracer = mock(Tracer.class);
+        GlobalTracer.register(mockTracer);
+        GlobalTracer.get().buildSpan("my-operation");
+
+        verify(mockTracer).buildSpan(eq("my-operation"));
+        verifyNoMoreInteractions(mockTracer);
+    }
+
+    @Test
+    public void testDelegation_inject() {
+        Tracer mockTracer = mock(Tracer.class);
+        SpanContext mockContext = mock(SpanContext.class);
+        Format<Object> mockFormat = mock(Format.class);
+        Object mockCarrier = mock(Object.class);
+        GlobalTracer.register(mockTracer);
+        GlobalTracer.get().inject(mockContext, mockFormat, mockCarrier);
+
+        verify(mockTracer).inject(eq(mockContext), eq(mockFormat), eq(mockCarrier));
+        verifyNoMoreInteractions(mockTracer, mockContext, mockFormat, mockCarrier);
+    }
+
+    @Test
+    public void testDelegation_extract() {
+        Tracer mockTracer = mock(Tracer.class);
+        Format<Object> mockFormat = mock(Format.class);
+        Object mockCarrier = mock(Object.class);
+        GlobalTracer.register(mockTracer);
+        GlobalTracer.get().extract(mockFormat, mockCarrier);
+
+        verify(mockTracer).extract(eq(mockFormat), eq(mockCarrier));
+        verifyNoMoreInteractions(mockTracer, mockFormat, mockCarrier);
+    }
+
+    @Test
+    public void concurrencyTest() throws InterruptedException, ExecutionException {
+        final int threadCount = 10;
+        ExecutorService threadpool = Executors.newFixedThreadPool(2 * threadCount);
+        try {
+            // Try to do ten register() calls and ten buildSpan() calls concurrently.
+            List<Callable<Void>> registerCalls = new ArrayList<Callable<Void>>();
+            List<Callable<Tracer.SpanBuilder>> buildSpanCalls = new ArrayList<Callable<Tracer.SpanBuilder>>();
+            for (int i = 0; i < threadCount; i++) {
+                registerCalls.add(new Callable<Void>() {
+                    @Override
+                    public Void call() throws Exception {
+                        GlobalTracer.register(mock(Tracer.class));
+                        return null;
+                    }
+                });
+                buildSpanCalls.add(new Callable<Tracer.SpanBuilder>() {
+                    @Override
+                    public Tracer.SpanBuilder call() throws Exception {
+                        return GlobalTracer.get().buildSpan("my-operation");
+                    }
+                });
+            }
+
+            // Schedule the threads.
+            List<Future<Void>> registerResults = threadpool.invokeAll(registerCalls);
+            List<Future<Tracer.SpanBuilder>> buildSpanResults = threadpool.invokeAll(buildSpanCalls);
+
+            boolean registered = false; // there may only be one registration success.
+            int exceptions = 0;
+            for (Future<Void> result : registerResults) {
+                try {
+                    result.get(); // void, but should throw exception 9 times
+                    assertThat("previous registration", registered, is(false));
+                    registered = true;
+                } catch (ExecutionException expected) {
+                    exceptions++;
+                }
+            }
+            assertThat("Tracer registration", registered, is(true));
+            assertThat("Registration exceptions", exceptions, is(threadCount - 1));
+
+            for (Future<Tracer.SpanBuilder> result : buildSpanResults) {
+                // each spanbuilder must be either null (from registered mock tracer) or noop
+                assertThat("SpanBuilder", result.get(), anyOf(nullValue(), instanceOf(NoopSpanBuilder.class)));
+            }
+
+        } finally {
+            threadpool.shutdown();
+        }
+    }
+
+    @Test
+    public void testIsRegistered() {
+        assertThat("Should not be registered", GlobalTracer.isRegistered(), is(false));
+        GlobalTracer.register(mock(Tracer.class));
+        assertThat("Should be registered", GlobalTracer.isRegistered(), is(true));
+    }
+
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/util/ThreadLocalActiveSpanSourceTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/util/ThreadLocalActiveSpanSourceTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.util;
+
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ThreadLocalActiveSpanSourceTest {
+    private ThreadLocalActiveSpanSource source;
+    @Before
+    public void before() throws Exception {
+        source = new ThreadLocalActiveSpanSource();
+    }
+
+    @Test
+    public void missingActiveSpan() throws Exception {
+        ActiveSpan missingSpan = source.activeSpan();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void makeActiveSpan() throws Exception {
+        Span span = mock(Span.class);
+
+        // We can't use 1.7 features like try-with-resources in this repo without meddling with pom details for tests.
+        ActiveSpan activeSpan = source.makeActive(span);
+        try {
+            assertNotNull(activeSpan);
+            ActiveSpan otherActiveSpan = source.activeSpan();
+            assertEquals(otherActiveSpan, activeSpan);
+        } finally {
+            activeSpan.close();
+        }
+
+        // Make sure the Span got finish()ed.
+        verify(span).finish();
+
+        // And now it's gone:
+        ActiveSpan missingSpan = source.activeSpan();
+        assertNull(missingSpan);
+    }
+
+}

--- a/opentracing-v030/src/test/java/io/opentracing/v_030/util/ThreadLocalActiveSpanTest.java
+++ b/opentracing-v030/src/test/java/io/opentracing/v_030/util/ThreadLocalActiveSpanTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ThreadLocalActiveSpanTest {
+    private ThreadLocalActiveSpanSource source;
+
+    @Before
+    public void before() throws Exception {
+        source = new ThreadLocalActiveSpanSource();
+    }
+
+    @Test
+    public void continuation() throws Exception {
+        Span span = mock(Span.class);
+
+        // Quasi try-with-resources (this is 1.6).
+        ActiveSpan activeSpan = source.makeActive(span);
+        ActiveSpan.Continuation continued = null;
+        try {
+            assertNotNull(activeSpan);
+            continued = activeSpan.capture();
+        } finally {
+            activeSpan.close();
+        }
+
+        // Make sure the Span was not finished since there was a capture().
+        verify(span, never()).finish();
+
+        // Activate the continuation.
+        try {
+            activeSpan = continued.activate();
+        } finally {
+            activeSpan.close();
+        }
+
+        // Now the Span should be finished.
+        verify(span, times(1)).finish();
+
+        // And now it's no longer active.
+        ActiveSpan missingSpan = source.activeSpan();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void implicitSpanStack() throws Exception {
+        Span backgroundSpan = mock(Span.class);
+        Span foregroundSpan = mock(Span.class);
+
+        // Quasi try-with-resources (this is 1.6).
+        ActiveSpan backgroundActive = source.makeActive(backgroundSpan);
+        try {
+            assertNotNull(backgroundActive);
+
+            // Activate a new ActiveSpan on top of the background one.
+            ActiveSpan foregroundActive = source.makeActive(foregroundSpan);
+            try {
+                ActiveSpan shouldBeForeground = source.activeSpan();
+                assertEquals(foregroundActive, shouldBeForeground);
+            } finally {
+                foregroundActive.close();
+            }
+
+            // And now the backgroundActive should be reinstated.
+            ActiveSpan shouldBeBackground = source.activeSpan();
+            assertEquals(backgroundActive, shouldBeBackground);
+        } finally {
+            backgroundActive.close();
+        }
+
+        // The background and foreground Spans should be finished.
+        verify(backgroundSpan, times(1)).finish();
+        verify(foregroundSpan, times(1)).finish();
+
+        // And now nothing is active.
+        ActiveSpan missingSpan = source.activeSpan();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void testDeactivateWhenDifferentSpanIsActive() {
+        Span span = mock(Span.class);
+
+        ActiveSpan activeSpan = source.makeActive(span);
+        source.makeActive(mock(Span.class));
+        activeSpan.deactivate();
+
+        verify(span, times(0)).finish();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <module>opentracing-mock</module>
         <module>opentracing-util</module>
         <module>opentracing-examples</module>
+        <module>opentracing-v030</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This is an updated PR for the compatibility layer for the 0.30 API.

The changes are mostly:

* Put all the 0.30 packages under a new `opentracing-v030` package (so not mess with the existing code). For keeping things uniform, the code from 0.30 has been mostly copied over.

* Have a `io.opentracing.v_030.shim.TracerShim` class to wrap `io.opentracing.Tracer` instances and expose them under the 0.30 API. This required the addition of `AutoFinishScopeManager`, which is a `ScopeManager` supporting reference count. I decided to put it under `util` as it may be used in other components later on, and not only the Shim (like in Scala asynchronous frameworks).

Any feedback is appreciated ;) Observe the idea is to let instrumentation authors to incrementally support the new API while keeping backwards compatibility against the old one.