### PR TITLE
Make MockTracer::ChildOf not fail if there is a null argument passed

### DIFF
--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -220,6 +220,9 @@ public class MockTracer implements Tracer {
 
         @Override
         public SpanBuilder asChildOf(BaseSpan parent) {
+            if (parent == null) {
+                return this;
+            }
             return addReference(References.CHILD_OF, parent.context());
         }
 

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockSpanTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockSpanTest.java
@@ -78,4 +78,12 @@ public class MockSpanTest {
         }
         Assert.assertEquals(1, tracer.finishedSpans().get(0).generatedErrors().size());
     }
+
+    @Test
+    public void testChaildOfWithNullParentDoesNotThrowException() {
+        MockTracer tracer = new MockTracer();
+        final Span parent = null;
+        Span span = tracer.buildSpan("foo").asChildOf(parent).start();
+        span.finish();
+    }
 }

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockSpanTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockSpanTest.java
@@ -78,12 +78,4 @@ public class MockSpanTest {
         }
         Assert.assertEquals(1, tracer.finishedSpans().get(0).generatedErrors().size());
     }
-
-    @Test
-    public void testChaildOfWithNullParentDoesNotThrowException() {
-        MockTracer tracer = new MockTracer();
-        final Span parent = null;
-        Span span = tracer.buildSpan("foo").asChildOf(parent).start();
-        span.finish();
-    }
 }

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -279,4 +279,12 @@ public class MockTracerTest {
         assertEquals(1, nextSpan.references().size());
         assertEquals(nextSpan.references().get(0), new MockSpan.Reference(parent.context(), "a_reference"));
     }
+
+    @Test
+    public void testChildOfWithNullParentDoesNotThrowException() {
+        MockTracer tracer = new MockTracer();
+        final Span parent = null;
+        Span span = tracer.buildSpan("foo").asChildOf(parent).start();
+        span.finish();
+    }
 }


### PR DESCRIPTION
According to [SpanBuilder interface](https://github.com/opentracing/opentracing-java/blob/master/opentracing-api/src/main/java/io/opentracing/Tracer.java#L106), `ChildOf` called with `null` parent should be a noop. This pull request fixes this behaviour for MockTracer.