### PR TITLE
Let Tracer.activeSpan() be a shorthand for ScopeManager's active Span.

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -26,7 +26,7 @@ public interface Tracer {
     ScopeManager scopeManager();
 
     /**
-     * @return the active {@link Span}. This is a shorthand for {@link Tracer#scopeManager()#active()#span()},
+     * @return the active {@link Span}. This is a shorthand for Tracer.scopeManager().active().span(),
      * and null will be returned if {@link Scope#active()} is null.
      */
     Span activeSpan();

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -26,7 +26,8 @@ public interface Tracer {
     ScopeManager scopeManager();
 
     /**
-     * @return the active {@link Span}, if any. This is a shorthand for {@link Tracer#scopeManager()#active()#span()}.
+     * @return the active {@link Span}. This is a shorthand for {@link Tracer#scopeManager()#active()#span()},
+     * and null will be returned if {@link Scope#active()} is null.
      */
     Span activeSpan();
 

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -26,6 +26,11 @@ public interface Tracer {
     ScopeManager scopeManager();
 
     /**
+     * @return the active {@link Span}, if any. This is a shorthand for {@link Tracer#scopeManager()#active()#span()}.
+     */
+    Span activeSpan();
+
+    /**
      * Return a new SpanBuilder for a Span with the given `operationName`.
      *
      * <p>You can override the operationName later via {@link Span#setOperationName(String)}.

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -182,6 +182,12 @@ public class MockTracer implements Tracer {
         return this.propagator.extract(format, carrier);
     }
 
+    @Override
+    public Span activeSpan() {
+        Scope scope = this.scopeManager.active();
+        return scope == null ? null : scope.span();
+    }
+
     synchronized void appendFinishedSpan(MockSpan mockSpan) {
         this.finishedSpans.add(mockSpan);
         this.onSpanFinished(mockSpan);

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -16,6 +16,7 @@ package io.opentracing.mock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -195,6 +196,22 @@ public class MockTracerTest {
         Assert.assertEquals(2, finishedSpans.size());
         Assert.assertEquals(finishedSpans.get(0).context().traceId(), finishedSpans.get(1).context().traceId());
         Assert.assertEquals(finishedSpans.get(0).context().spanId(), finishedSpans.get(1).parentId());
+    }
+
+    @Test
+    public void testActiveSpan() {
+        MockTracer mockTracer = new MockTracer();
+        Assert.assertNull(mockTracer.activeSpan());
+
+        Scope scope = null;
+        try {
+            scope = mockTracer.buildSpan("foo").startActive(true);
+            Assert.assertEquals(mockTracer.scopeManager().active().span(), mockTracer.activeSpan());
+        } finally {
+            scope.close();
+        }
+
+        Assert.assertNull(mockTracer.activeSpan());
     }
 
     @Test

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
@@ -14,6 +14,7 @@
 package io.opentracing.noop;
 
 import io.opentracing.ScopeManager;
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
@@ -37,6 +38,11 @@ final class NoopTracerImpl implements NoopTracer {
 
     @Override
     public <C> SpanContext extract(Format<C> format, C carrier) { return NoopSpanBuilderImpl.INSTANCE; }
+
+    @Override
+    public Span activeSpan() {
+        return NoopSpan.INSTANCE;
+    }
 
     @Override
     public String toString() { return NoopTracer.class.getSimpleName(); }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
@@ -31,6 +31,11 @@ final class NoopTracerImpl implements NoopTracer {
     }
 
     @Override
+    public Span activeSpan() {
+        return null;
+    }
+
+    @Override
     public SpanBuilder buildSpan(String operationName) { return NoopSpanBuilderImpl.INSTANCE; }
 
     @Override
@@ -38,11 +43,6 @@ final class NoopTracerImpl implements NoopTracer {
 
     @Override
     public <C> SpanContext extract(Format<C> format, C carrier) { return NoopSpanBuilderImpl.INSTANCE; }
-
-    @Override
-    public Span activeSpan() {
-        return NoopSpan.INSTANCE;
-    }
 
     @Override
     public String toString() { return NoopTracer.class.getSimpleName(); }

--- a/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
@@ -14,6 +14,7 @@
 package io.opentracing.util;
 
 import io.opentracing.ScopeManager;
+import io.opentracing.Span;
 import io.opentracing.noop.NoopTracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.opentracing.SpanContext;
@@ -140,6 +141,11 @@ public final class GlobalTracer implements Tracer {
     @Override
     public <C> SpanContext extract(Format<C> format, C carrier) {
         return tracer.extract(format, carrier);
+    }
+
+    @Override
+    public Span activeSpan() {
+        return tracer.activeSpan();
     }
 
     @Override


### PR DESCRIPTION
This is a small PR intended to address #227 as a way to provide a shorthand for getting the active span from a `Tracer`.

One alternative would have been to have `Tracer.activeScope()` but that would only save us from typing `scopeManager()`, so not much save here. 