### PR TITLE
Use correct reference in io.opentracing.propagation.Format Javadoc

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
  * <pre><code>
  * Tracer tracer = ...
  * io.opentracing.propagation.HttpHeaders httpCarrier = new AnHttpHeaderCarrier(httpRequest);
- * SpanContext spanCtx = tracer.extract(Format.Builtin.HTTP_HEADERS, httpHeaderReader);
+ * SpanContext spanCtx = tracer.extract(Format.Builtin.HTTP_HEADERS, httpCarrier);
  * </code></pre>
  *
  * @see Tracer#inject(SpanContext, Format, Object)


### PR DESCRIPTION
Format.java specifies a carrier, but then refers to a non-existant reader in the Javadoc example.  Changed to use carrier.