### PR TITLE
V0.31.0 rebased on master (for Final RC).

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
  * <pre><code>
  * Tracer tracer = ...
  * io.opentracing.propagation.HttpHeaders httpCarrier = new AnHttpHeaderCarrier(httpRequest);
- * SpanContext spanCtx = tracer.extract(Format.Builtin.HTTP_HEADERS, httpHeaderReader);
+ * SpanContext spanCtx = tracer.extract(Format.Builtin.HTTP_HEADERS, httpCarrier);
  * </code></pre>
  *
  * @see Tracer#inject(SpanContext, Format, Object)

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.Map;
 
 public interface NoopSpanBuilder extends Tracer.SpanBuilder, NoopSpanContext {
-    static final NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
+    NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
 }
 
 final class NoopSpanBuilderImpl implements NoopSpanBuilder {
@@ -82,7 +82,7 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
 
     @Override
     public Iterable<Map.Entry<String, String>> baggageItems() {
-        return Collections.EMPTY_MAP.entrySet();
+        return Collections.<String, String>emptyMap().entrySet();
     }
 
     @Override

--- a/opentracing-util/pom.xml
+++ b/opentracing-util/pom.xml
@@ -42,4 +42,24 @@
             <artifactId>opentracing-noop</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*TestUtil.*</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/opentracing-util/src/test/java/io/opentracing/util/GlobalTracerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/GlobalTracerTest.java
@@ -29,9 +29,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopSpanBuilder;
-import io.opentracing.noop.NoopTracerFactory;
 import io.opentracing.propagation.Format;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -45,21 +43,10 @@ import org.junit.Test;
 
 public class GlobalTracerTest {
 
-    private static void _setGlobal(Tracer tracer) {
-        try {
-            Field globalTracerField = GlobalTracer.class.getDeclaredField("tracer");
-            globalTracerField.setAccessible(true);
-            globalTracerField.set(null, tracer);
-            globalTracerField.setAccessible(false);
-        } catch (Exception e) {
-            throw new RuntimeException("Error reflecting globalTracer: " + e.getMessage(), e);
-        }
-    }
-
     @Before
     @After
     public void clearGlobalTracer() {
-        _setGlobal(NoopTracerFactory.create());
+        GlobalTracerTestUtil.resetGlobalTracer();
     }
 
     @Test

--- a/opentracing-util/src/test/java/io/opentracing/util/GlobalTracerTestUtil.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/GlobalTracerTestUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util;
+
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopTracerFactory;
+
+import java.lang.reflect.Field;
+
+/**
+ * Utility class for manipulating the {@link GlobalTracer} when testing.
+ * <p>
+ * The {@linkplain GlobalTracer} has register-once semantics, but for testing purposes it is useful to
+ * manipulate the globaltracer to guarantee certain preconditions.
+ * <p>
+ * The {@code GlobalTracerTestUtil} can be included in your own code by adding the following dependency:
+ * <pre><code>
+ *     &lt;dependency>
+ *         &lt;groupId>io.opentracing&lt;/groupId>
+ *         &lt;artifactId>opentracing-util&lt;/artifactId>
+ *         &lt;version><em>version</em>&lt;/version>
+ *         <strong>&lt;type>test-jar&lt;/type></strong>
+ *         &lt;scope>test&lt;/scope>
+ *      &lt;/dependency>
+ * </code></pre>
+ */
+public class GlobalTracerTestUtil {
+
+    private GlobalTracerTestUtil() {
+        throw new UnsupportedOperationException("Cannot instantiate static test utility class.");
+    }
+
+    /**
+     * Resets the {@link GlobalTracer} to its initial, unregistered state.
+     */
+    public static void resetGlobalTracer() {
+        setGlobalTracerUnconditionally(NoopTracerFactory.create());
+    }
+
+    /**
+     * Unconditionally sets the {@link GlobalTracer} to the specified {@link Tracer tracer} instance.
+     *
+     * @param tracer The tracer to become the GlobalTracer's delegate.
+     */
+    public static void setGlobalTracerUnconditionally(Tracer tracer) {
+        try {
+            Field globalTracerField = GlobalTracer.class.getDeclaredField("tracer");
+            globalTracerField.setAccessible(true);
+            globalTracerField.set(null, tracer);
+            globalTracerField.setAccessible(false);
+        } catch (Exception e) {
+            throw new IllegalStateException("Error reflecting GlobalTracer.tracer: " + e.getMessage(), e);
+        }
+    }
+
+}


### PR DESCRIPTION
Hey everybody,

In order to prepare to roll out the second (and final) Release Candidate for the 0.31 artifact, I went and rebased the v0.31 branch on top of the misc fixes/patches that master has been received during this development stage.

This will mean that not only a few improvements done on top of the Scope concept will be rolled for RC2, but also fixes or adjustments like the usage of TextMap as default propagator for MockTracer.

Observe that:

Rebasing v0.31 on top of master didn't rebase cleanly, but fortunately only minor adjustments were needed.

We will be rolling this final RC from the v0.31 branch, and we will hopefully release the final 0.31 artifact from master ;)

Let me know. I went through the changes a pair of times and ran the tests, so hopefully everything is just fine. As of @malafeev and @yurishkuro suggestion (on a prior PR), we could merge directly and review later on. So I guess I will do that soon unless somebody has objections ;)