### PR TITLE
Auto finish scope manager

### DIFF
--- a/opentracing-examples/src/test/java/io/opentracing/examples/activate_deactivate/RunnableAction.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/activate_deactivate/RunnableAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-examples/src/test/java/io/opentracing/examples/activate_deactivate/RunnableAction.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/activate_deactivate/RunnableAction.java
@@ -13,8 +13,8 @@
  */
 package io.opentracing.examples.activate_deactivate;
 
-import io.opentracing.examples.AutoFinishScope;
-import io.opentracing.examples.AutoFinishScope.Continuation;
+import io.opentracing.util.AutoFinishScope;
+import io.opentracing.util.AutoFinishScope.Continuation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/opentracing-examples/src/test/java/io/opentracing/examples/activate_deactivate/ScheduledActionsTest.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/activate_deactivate/ScheduledActionsTest.java
@@ -14,8 +14,8 @@
 package io.opentracing.examples.activate_deactivate;
 
 import io.opentracing.Scope;
-import io.opentracing.examples.AutoFinishScope;
-import io.opentracing.examples.AutoFinishScopeManager;
+import io.opentracing.util.AutoFinishScope;
+import io.opentracing.util.AutoFinishScopeManager;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.mock.MockTracer.Propagator;

--- a/opentracing-examples/src/test/java/io/opentracing/examples/activate_deactivate/ScheduledActionsTest.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/activate_deactivate/ScheduledActionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-examples/src/test/java/io/opentracing/examples/multiple_callbacks/Client.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/multiple_callbacks/Client.java
@@ -15,8 +15,8 @@ package io.opentracing.examples.multiple_callbacks;
 
 import io.opentracing.Scope;
 import io.opentracing.Tracer;
-import io.opentracing.examples.AutoFinishScope;
-import io.opentracing.examples.AutoFinishScope.Continuation;
+import io.opentracing.util.AutoFinishScope;
+import io.opentracing.util.AutoFinishScope.Continuation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/opentracing-examples/src/test/java/io/opentracing/examples/multiple_callbacks/Client.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/multiple_callbacks/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-examples/src/test/java/io/opentracing/examples/multiple_callbacks/MultipleCallbacksTest.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/multiple_callbacks/MultipleCallbacksTest.java
@@ -14,7 +14,7 @@
 package io.opentracing.examples.multiple_callbacks;
 
 import io.opentracing.Scope;
-import io.opentracing.examples.AutoFinishScopeManager;
+import io.opentracing.util.AutoFinishScopeManager;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.mock.MockTracer.Propagator;

--- a/opentracing-examples/src/test/java/io/opentracing/examples/multiple_callbacks/MultipleCallbacksTest.java
+++ b/opentracing-examples/src/test/java/io/opentracing/examples/multiple_callbacks/MultipleCallbacksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScope.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScope.java
@@ -11,7 +11,8 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opentracing.examples;
+
+package io.opentracing.util;
 
 import io.opentracing.Scope;
 import io.opentracing.Span;

--- a/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScope.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opentracing.examples;
+package io.opentracing.util;
 
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;

--- a/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-util/src/test/java/io/opentracing/util/AutoFinishScopeManagerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/AutoFinishScopeManagerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class AutoFinishScopeManagerTest {
+    private AutoFinishScopeManager source;
+    @Before
+    public void before() throws Exception {
+        source = new AutoFinishScopeManager();
+    }
+
+    @Test
+    public void missingScope() throws Exception {
+        Scope missingSpan = source.active();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void activateSpan() throws Exception {
+        Span span = mock(Span.class);
+
+        // We can't use 1.7 features like try-with-resources in this repo without meddling with pom details for tests.
+        Scope active = source.activate(span, true);
+        try {
+            assertNotNull(active);
+            Scope otherScope = source.active();
+            assertEquals(otherScope, active);
+        } finally {
+            active.close();
+        }
+
+        // Make sure the Span got finish()ed.
+        verify(span).finish();
+
+        // And now it's gone:
+        Scope missingSpan = source.active();
+        assertNull(missingSpan);
+    }
+}

--- a/opentracing-util/src/test/java/io/opentracing/util/AutoFinishScopeTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/AutoFinishScopeTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AutoFinishScopeTest {
+    private AutoFinishScopeManager manager;
+
+    @Before
+    public void before() throws Exception {
+        manager = new AutoFinishScopeManager();
+    }
+
+    @Test
+    public void continuation() throws Exception {
+        Span span = mock(Span.class);
+
+        // Quasi try-with-resources (this is 1.6).
+        AutoFinishScope active = (AutoFinishScope)manager.activate(span, true);
+        AutoFinishScope.Continuation continued = null;
+        try {
+            assertNotNull(active);
+            continued = active.capture();
+        } finally {
+            active.close();
+        }
+
+        // Make sure the Span was not finished since there was a capture().
+        verify(span, never()).finish();
+
+        // Activate the continuation.
+        try {
+            active = continued.activate();
+        } finally {
+            active.close();
+        }
+
+        // Now the Span should be finished.
+        verify(span, times(1)).finish();
+
+        // And now it's no longer active.
+        Scope missingSpan = manager.active();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void implicitSpanStack() throws Exception {
+        Span backgroundSpan = mock(Span.class);
+        Span foregroundSpan = mock(Span.class);
+
+        // Quasi try-with-resources (this is 1.6).
+        Scope backgroundActive = manager.activate(backgroundSpan, true);
+        try {
+            assertNotNull(backgroundActive);
+
+            // Activate a new Scope on top of the background one.
+            Scope foregroundActive = manager.activate(foregroundSpan, true);
+            try {
+                Scope shouldBeForeground = manager.active();
+                assertEquals(foregroundActive, shouldBeForeground);
+            } finally {
+                foregroundActive.close();
+            }
+
+            // And now the backgroundActive should be reinstated.
+            Scope shouldBeBackground = manager.active();
+            assertEquals(backgroundActive, shouldBeBackground);
+        } finally {
+            backgroundActive.close();
+        }
+
+        // The background and foreground Spans should be finished.
+        verify(backgroundSpan, times(1)).finish();
+        verify(foregroundSpan, times(1)).finish();
+
+        // And now nothing is active.
+        Scope missingSpan = manager.active();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void testDeactivateWhenDifferentSpanIsActive() {
+        Span span = mock(Span.class);
+
+        Scope active = manager.activate(span, true);
+        manager.activate(mock(Span.class), true);
+        active.close();
+
+        verify(span, times(0)).finish();
+    }
+}


### PR DESCRIPTION
Creating this PR in order to move the `AutoFinishScopeManager` from the examples module into the util one, so this can be accessible to other libraries (even if we don't support the `Continuation` concept out of the box anymore).

I'm playing with this possibility as both the v030 and the akka support will optionally offer this flavor of `ScopeManager`, and thought it could be helpful for other people/projects overall.

Opinions on this? Shall we put it here and expose it publicly? 