### PR TITLE
Make Binary use byte arrays instead of ByteBuffer instances.

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/propagation/Adapters.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Adapters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -36,23 +36,7 @@ public final class Adapters {
             throw new IllegalArgumentException("stream cannot be null");
         }
 
-        return new BinaryAdapter(Channels.newChannel(stream));
-    }
-
-    /**
-     * Creates an outbound Binary instance used for injection, backed up
-     * by the specified WritableByteChannel as the output.
-     *
-     * @param channel The WritableByteChannel used as output.
-     *
-     * @return The new Binary carrier used for injection.
-     */
-    public static Binary injectBinary(WritableByteChannel channel) {
-        if (channel == null) {
-            throw new IllegalArgumentException("channel cannot be null");
-        }
-
-        return new BinaryAdapter(channel);
+        return new BinaryAdapter(stream);
     }
 
     /**
@@ -68,22 +52,6 @@ public final class Adapters {
             throw new IllegalArgumentException("stream cannot be null");
         }
 
-        return new BinaryAdapter(Channels.newChannel(stream));
-    }
-
-    /**
-     * Creates an inbound Binary instance used for extraction with the
-     * specified ReadableByteChannel as the input.
-     *
-     * @param channel The ReadableByteChannel used as input.
-     *
-     * @return The new Binary carrier used for extraction.
-     */
-    public static Binary extractBinary(ReadableByteChannel channel) {
-        if (channel == null) {
-            throw new IllegalArgumentException("channel cannot be null");
-        }
-
-        return new BinaryAdapter(channel);
+        return new BinaryAdapter(stream);
     }
 }

--- a/opentracing-api/src/main/java/io/opentracing/propagation/Binary.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Binary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -33,25 +33,27 @@ import java.nio.ByteBuffer;
  */
 public interface Binary {
     /**
-     * Writes a sequence of bytes to this channel from the given buffer.
-     * The internal buffer is expected to grow as more data is written.
+     * Writes len bytes from the specified byte array starting at offset off to this carrier.
      *
-     * The behavior of this method is expected to be the same as WritableByteChannel.write().
+     * The behavior of this method is expected to be the same as OutputStream.write().
      *
-     * @param buffer The buffer from which bytes are to be retrieved.
-     *
-     * @return The number of bytes written, possibly zero.
+     * @param b the data.
+     * @param off the start offset of the data.
+     * @param len the number of bytes to write.
      */
-    int write(ByteBuffer buffer) throws IOException;
+    void write(byte[] b, int off, int len) throws IOException;
 
     /**
-     * Reads a sequence of bytes into the given buffer.
+     * Reads up to len bytes of data from the carrier into an array of bytes.
      *
-     * The behavior of this method is expected to be the same as ReadableByteChannel.read().
+     * The behavior of this method is expected to be the same as InputStream.read().
      *
-     * @param buffer The buffer into which bytes are to be transferred.
+     * @param b the data.
+     * @param off the start offset of the data.
+     * @param len the number of bytes to read.
      *
-     * @return The number of bytes read, possibly zero, or -1 if the channel has reached end-of-stream.
+     * @return the total number of bytes read into the buffer, or -1 if there is no more data
+     * because the end of the carrier has been reached.
      */
-    int read(ByteBuffer buffer) throws IOException;
+    int read(byte[] b, int offset, int len) throws IOException;
 }

--- a/opentracing-api/src/main/java/io/opentracing/propagation/BinaryAdapter.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/BinaryAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,56 +14,55 @@
 package io.opentracing.propagation;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.WritableByteChannel;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * BinaryAdapter is a built-in carrier for Tracer.inject() and Tracer.extract(). BinaryAdapter
- * is backed up by either a ReadableByteChannel or a WritableByteChannel, depending
+ * is backed up by either an InputStream or an OutputStream, depending
  * on whether it's defined as injection or extraction, respectively.
  */
 final class BinaryAdapter implements Binary {
-    private final ReadableByteChannel readChannel;
-    private final WritableByteChannel writeChannel;
+    private final InputStream inputStream;
+    private final OutputStream outputStream;
 
     /**
-     * Create an outbound BinaryAdapter backed by the specified write channel.
+     * Create an outbound BinaryAdapter backed by the specified OutputStream.
      */
-    BinaryAdapter(WritableByteChannel writeChannel) {
-        this.writeChannel = writeChannel;
-        this.readChannel = null;
+    BinaryAdapter(OutputStream outputStream) {
+        this.outputStream = outputStream;
+        this.inputStream = null;
     }
 
     /**
-     * Create an inbound BinaryAdapter backed by the specified read channel.
+     * Create an inbound BinaryAdapter backed by the specified InputStream.
      */
-    BinaryAdapter(ReadableByteChannel readChannel) {
-        this.readChannel = readChannel;
-        this.writeChannel = null;
+    BinaryAdapter(InputStream inputStream) {
+        this.inputStream = inputStream;
+        this.outputStream = null;
     }
 
-    ReadableByteChannel readChannel() {
-        return readChannel;
+    InputStream inputStream() {
+        return inputStream;
     }
 
-    WritableByteChannel writeChannel() {
-        return writeChannel;
+    OutputStream outputStream() {
+        return outputStream;
     }
 
-    public int write(ByteBuffer buffer) throws IOException {
-        if (writeChannel == null) {
+    public void write(byte[] b, int off, int len) throws IOException {
+        if (outputStream == null) {
             throw new UnsupportedOperationException();
         }
 
-        return writeChannel.write(buffer);
+        outputStream.write(b, off, len);
     }
 
-    public int read(ByteBuffer buffer) throws IOException {
-        if (readChannel == null) {
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (inputStream == null) {
             throw new UnsupportedOperationException();
         }
 
-        return readChannel.read(buffer);
+        return inputStream.read(b, off, len);
     }
 }

--- a/opentracing-api/src/test/java/io/opentracing/propagation/AdaptersTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/propagation/AdaptersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -32,47 +32,22 @@ public class AdaptersTest {
     public void testExtractBinaryStream() {
         byte[] ctx = new byte[0];
         BinaryAdapter binary = (BinaryAdapter) Adapters.extractBinary(new ByteArrayInputStream(ctx));
-        assertNotNull(binary.readChannel());
-    }
-
-    @Test
-    public void testExtractBinaryChannel() {
-        byte[] ctx = new byte[0];
-        ReadableByteChannel channel = Channels.newChannel(new ByteArrayInputStream(new byte[0]));
-        BinaryAdapter binary = (BinaryAdapter) Adapters.extractBinary(channel);
-        assertEquals(channel, binary.readChannel());
+        assertNotNull(binary.inputStream());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testExtractNullStream() {
-        Adapters.extractBinary((InputStream)null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testExtractNullChannel() {
-        Adapters.extractBinary((ReadableByteChannel)null);
+        Adapters.extractBinary(null);
     }
 
     @Test
     public void testInjectBinaryStream() {
         BinaryAdapter binary = (BinaryAdapter) Adapters.injectBinary(new ByteArrayOutputStream());
-        assertNotNull(binary.writeChannel());
-    }
-
-    @Test
-    public void testInjectBinaryChannel() {
-        WritableByteChannel channel = Channels.newChannel(new ByteArrayOutputStream());
-        BinaryAdapter binary = (BinaryAdapter) Adapters.injectBinary(channel);
-        assertEquals(channel, binary.writeChannel());
+        assertNotNull(binary.outputStream());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testInjectNullStream() {
-        Adapters.injectBinary((OutputStream)null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testInjectNullChannel() {
-        Adapters.injectBinary((WritableByteChannel)null);
+        Adapters.injectBinary(null);
     }
 }

--- a/opentracing-api/src/test/java/io/opentracing/propagation/BinaryAdapterTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/propagation/BinaryAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,31 +30,29 @@ public class BinaryAdapterTest {
     @Test
     public void testRead() throws IOException {
         ByteArrayInputStream stream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 4, 3, 2, 1 });
-        BinaryAdapter binary = new BinaryAdapter(Channels.newChannel(stream));
-        assertNotNull(binary.readChannel());
-        assertNull(binary.writeChannel());
+        BinaryAdapter binary = new BinaryAdapter(stream);
+        assertNotNull(binary.inputStream());
+        assertNull(binary.outputStream());
 
-        ByteBuffer buffer = ByteBuffer.allocate(4);
-        assertEquals(4, binary.read(buffer));
-        assertArrayEquals(new byte[] { 1, 2, 3, 4 }, buffer.array());
+        byte[] buff = new byte[4];
+        assertEquals(4, binary.read(buff, 0, buff.length));
+        assertArrayEquals(new byte[] { 1, 2, 3, 4 }, buff);
 
-        buffer.rewind();
-        assertEquals(4, binary.read(buffer));
-        assertArrayEquals(new byte[] { 4, 3, 2, 1 }, buffer.array());
+        assertEquals(4, binary.read(buff, 0, buff.length));
+        assertArrayEquals(new byte[] { 4, 3, 2, 1 }, buff);
 
-        buffer.rewind();
-        assertEquals(-1, binary.read(buffer));
+        assertEquals(-1, binary.read(buff, 0, buff.length));
     }
 
     @Test
     public void testWrite() throws IOException {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        BinaryAdapter binary = new BinaryAdapter(Channels.newChannel(stream));
-        assertNotNull(binary.writeChannel());
-        assertNull(binary.readChannel());
+        BinaryAdapter binary = new BinaryAdapter(stream);
+        assertNotNull(binary.outputStream());
+        assertNull(binary.inputStream());
 
-        assertEquals(4, binary.write(ByteBuffer.wrap(new byte [] { 1, 2, 3, 4 })));
-        assertEquals(4, binary.write(ByteBuffer.wrap(new byte [] { 4, 3, 2, 1 })));
+        binary.write(new byte [] { 1, 2, 3, 4 }, 0, 4);
+        binary.write(new byte [] { 4, 3, 2, 1 }, 0, 4);
 
         assertArrayEquals(new byte[] { 1, 2, 3, 4, 4, 3, 2, 1 }, stream.toByteArray());
     }

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -139,7 +139,9 @@ public class MockTracer implements Tracer {
                         }
 
                         objStream.flush(); // *need* to flush ObjectOutputStream.
-                        binary.write(ByteBuffer.wrap(stream.toByteArray()));
+
+                        byte[] arr = stream.toByteArray();
+                        binary.write(arr, 0, arr.length);
 
                     } catch (IOException e) {
                         throw new RuntimeException("Corrupted state");
@@ -164,9 +166,10 @@ public class MockTracer implements Tracer {
                     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                     ObjectInputStream objStream = null;
                     try {
-                        ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
-                        for (int readBytes = 0; (readBytes = binary.read(buffer)) > 0; buffer.rewind()) {
-                            outputStream.write(buffer.array(), 0, readBytes);
+                        byte[] buff = new byte[BUFFER_SIZE];
+                        int res;
+                        while ((res = binary.read(buff, 0, buff.length)) > 0) {
+                            outputStream.write(buff, 0, res);
                         }
 
                         objStream = new ObjectInputStream(new ByteArrayInputStream(outputStream.toByteArray()));

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -168,7 +168,7 @@ public class MockTracer implements Tracer {
                     try {
                         byte[] buff = new byte[BUFFER_SIZE];
                         int res;
-                        while ((res = binary.read(buff, 0, buff.length)) > 0) {
+                        while ((res = binary.read(buff, 0, buff.length)) > -1) {
                             outputStream.write(buff, 0, res);
                         }
 


### PR DESCRIPTION
This is an approach for 'solving' #243, as a compromise between streams and `ByteBuffer` approaches.

Adapters for `Channel`s have been removed, but we can include them in next releases if still desired.

`MockTracer` has been updated as well.