### PR TITLE
Binary release adjustments

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/propagation/Binary.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Binary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -36,7 +36,8 @@ public interface Binary {
      * Writes a sequence of bytes to this carrier from the given buffer.
      * The internal buffer is expected to grow as more data is written.
      *
-     * The behavior of this method is expected to be the same as WritableByteChannel.write().
+     * The behavior of this method is expected to be the same as WritableByteChannel.write(),
+     * with the exception of being synchronous.
      *
      * @param buffer The buffer from which bytes are to be retrieved.
      *
@@ -47,7 +48,8 @@ public interface Binary {
     /**
      * Reads a sequence of bytes into the given buffer.
      *
-     * The behavior of this method is expected to be the same as ReadableByteChannel.read().
+     * The behavior of this method is expected to be the same as ReadableByteChannel.read(),
+     * with the exception of being synchronous.
      *
      * @param buffer The buffer into which bytes are to be transferred.
      *

--- a/opentracing-api/src/main/java/io/opentracing/propagation/Binary.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Binary.java
@@ -33,7 +33,7 @@ import java.nio.ByteBuffer;
  */
 public interface Binary {
     /**
-     * Writes a sequence of bytes to this channel from the given buffer.
+     * Writes a sequence of bytes to this carrier from the given buffer.
      * The internal buffer is expected to grow as more data is written.
      *
      * The behavior of this method is expected to be the same as WritableByteChannel.write().
@@ -51,7 +51,7 @@ public interface Binary {
      *
      * @param buffer The buffer into which bytes are to be transferred.
      *
-     * @return The number of bytes read, possibly zero, or -1 if the channel has reached end-of-stream.
+     * @return The number of bytes read, possibly zero, or -1 if the carrier has reached end-of-stream.
      */
     int read(ByteBuffer buffer) throws IOException;
 }

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -139,7 +139,11 @@ public class MockTracer implements Tracer {
                         }
 
                         objStream.flush(); // *need* to flush ObjectOutputStream.
-                        binary.write(ByteBuffer.wrap(stream.toByteArray()));
+
+                        ByteBuffer buff = ByteBuffer.wrap(stream.toByteArray());
+                        while (buff.hasRemaining()) {
+                            binary.write(buff);
+                        }
 
                     } catch (IOException e) {
                         throw new RuntimeException("Corrupted state");

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,8 +17,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
+import java.io.IOException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +34,7 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Adapters;
+import io.opentracing.propagation.Binary;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMapExtractAdapter;
 import io.opentracing.propagation.TextMapInjectAdapter;
@@ -236,6 +239,51 @@ public class MockTracerTest {
         Assert.assertNull(finishedSpans.get(0).getBaggageItem("barbag"));
         Assert.assertEquals("fooitem", finishedSpans.get(1).getBaggageItem("foobag"));
         Assert.assertEquals("baritem", finishedSpans.get(1).getBaggageItem("barbag"));
+    }
+
+    @Test
+    public void testBinaryPropagatorStream() {
+        MockTracer tracer = new MockTracer(MockTracer.Propagator.BINARY);
+        {
+            Span parentSpan = tracer.buildSpan("foo")
+                    .start();
+            parentSpan.finish();
+
+            ByteByByteBinary buff = new ByteByByteBinary();
+            tracer.inject(parentSpan.context(), Format.Builtin.BINARY, buff);
+
+            ByteArrayInputStream extractStream = new ByteArrayInputStream(buff.toByteArray());
+            SpanContext extract = tracer.extract(Format.Builtin.BINARY, Adapters.extractBinary(extractStream));
+
+            Span childSpan = tracer.buildSpan("bar")
+                    .asChildOf(extract)
+                    .start();
+            childSpan.finish();
+        }
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+
+        Assert.assertEquals(2, finishedSpans.size());
+        Assert.assertEquals(finishedSpans.get(0).context().traceId(), finishedSpans.get(1).context().traceId());
+        Assert.assertEquals(finishedSpans.get(0).context().spanId(), finishedSpans.get(1).parentId());
+    }
+
+    // Binary format that only writes one byte at a time, thus needing
+    // multiple calls to write() when calling inject().
+    class ByteByByteBinary implements Binary {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+
+        public byte[] toByteArray() {
+            return stream.toByteArray();
+        }
+
+        public int write(ByteBuffer buffer) throws IOException {
+            stream.write(new byte[] { buffer.get() });
+            return 1;
+        }
+
+        public int read(ByteBuffer buffer) throws IOException {
+            return -1;
+        }
     }
   
     @Test


### PR DESCRIPTION
This is a PR to update `MockTracer` and the inline documentation for `Binary` prior to the 0.31 release (after the feedback we got in #243).

* MockTracer's Binary propagator must loop over `Binary.write()` when injecting a context (instead of a *single* write() ).
* Clarify that the `Binary` methods for reading/writing *work* like the ones of a (synchronous) `Channel`, but they don't need to belong to an actual `Channel`.