### PR TITLE
Add "Automatic-Module-Name" entries to MANIFEST.MF.

### DIFF
--- a/opentracing-api/pom.xml
+++ b/opentracing-api/pom.xml
@@ -33,4 +33,19 @@
         <main.signature.artifact>java16</main.signature.artifact>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.opentracing.api</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/opentracing-mock/pom.xml
+++ b/opentracing-mock/pom.xml
@@ -46,4 +46,19 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.opentracing.mock</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/opentracing-noop/pom.xml
+++ b/opentracing-noop/pom.xml
@@ -38,4 +38,20 @@
             <artifactId>opentracing-api</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.opentracing.noop</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/opentracing-util/pom.xml
+++ b/opentracing-util/pom.xml
@@ -56,9 +56,21 @@
                             <includes>
                                 <include>**/*TestUtil.*</include>
                             </includes>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>io.opentracing.util.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.opentracing.util</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
In preparation for Java 9 jigsaw modularization.

Currently, trying to release a java 9 modularized library that requires the opentracing API will use an "Automatic Module" in Jigsaw.
However, depending on this module will generate warnings, as its name is not reserved yet (and based off the jar name e.g. without the `io.opentracing` prefix).

[This blog post](http://branchandbound.net/blog/java/2017/12/automatic-module-name/) describes why it is a good idea to start providing `Automatic-Module-Name` entries in `MANIFEST.MF` files for libraries, even if they're not yet fully modularized.

This effectively only 'claims' the name for the automatic
modules:
- io.opentracing.api
- io.opentracing.noop
- io.opentracing.util
- io.opentracing.mock
- io.opentracing.util.tests