### PR TITLE
Deprecate the StringTag.set() overload taking a StringTag.

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/tag/StringTag.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/StringTag.java
@@ -25,6 +25,10 @@ public class StringTag extends AbstractTag<String> {
         span.setTag(super.key, tagValue);
     }
 
+    /**
+     * @deprecated as using the tag *key* as tag value is not usually required.
+     */
+    @Deprecated
     public void set(Span span, StringTag tag) {
         span.setTag(super.key, tag.key);
     }


### PR DESCRIPTION
It's not a common scenario to use a Tag *key* as the tag value. Would fix #229 