### PR TITLE
Enabling NOOP classes to work with pre-existing production code

### DIFF
--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
@@ -36,7 +36,7 @@ class NoopScopeManagerImpl implements NoopScopeManager {
 
     @Override
     public Scope active() {
-        return null;
+        return NoopScope.INSTANCE;
     }
 
     static class NoopScopeImpl implements NoopScopeManager.NoopScope {

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
@@ -32,7 +32,7 @@ final class NoopTracerImpl implements NoopTracer {
 
     @Override
     public Span activeSpan() {
-        return null;
+        return NoopSpanImpl.INSTANCE;
     }
 
     @Override

--- a/opentracing-noop/src/test/java/io/opentracing/noop/NoopScopeManagerTest.java
+++ b/opentracing-noop/src/test/java/io/opentracing/noop/NoopScopeManagerTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.noop;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.opentracing.Scope;
+
+public class NoopScopeManagerTest {
+
+    @Test
+    public void activeValueToleratesUseTest() {
+        try{
+            final Scope active = NoopScopeManager.INSTANCE.active();
+            assertNotNull(active);
+            active.close();
+        } catch (final NullPointerException e) {
+            fail("NoopScopeManagerImpl.active() should return a usable scope");
+        }
+    }
+}

--- a/opentracing-noop/src/test/java/io/opentracing/noop/NoopTracerTest.java
+++ b/opentracing-noop/src/test/java/io/opentracing/noop/NoopTracerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.noop;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+
+public class NoopTracerTest {
+
+    @Test
+    public void activeSpanValueToleratesUseTest() {
+        try {
+            final Span activeSpan = NoopTracerImpl.INSTANCE.activeSpan();
+            assertNotNull(activeSpan);
+            Tags.ERROR.set(activeSpan, true);
+        } catch (final NullPointerException e) {
+            fail("NoopTracer.activeSpan() should return a usable span");
+        }
+    }
+}


### PR DESCRIPTION
In special circumstances, code may automatically generate spans,
negating the need to always check if `Tracer.activeSpan()` is `null`. Under these
circumstances, the Noop Tracer and ScopeManager will cause NPEs when they return
`null` values when their `active` methods are accessed via the GlobalTracer. This
prevents code from running successfully when using Noop Tracers.

This minor change allows users to depend that their code will genuinely Noop
under all use cases.

Signed-off-by: Nate Hart <nhart@tableau.com>