### PR TITLE
Updating the Mock Tests To Use Proper Scope Manager

### DIFF
--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -59,7 +59,7 @@ public class MockTracer implements Tracer {
      * Create a new MockTracer that passes through any calls to inject() and/or extract().
      */
     public MockTracer(Propagator propagator) {
-        this(NoopScopeManager.INSTANCE, propagator);
+        this(new ThreadLocalScopeManager(), propagator);
     }
 
     /**


### PR DESCRIPTION
Currently, the no-argument constructor for the MockTracer uses a `ThreadLocalScopeManager`
and a `Propagator.TEXT_MAP` as default values. But when providing a Propagator,
the constructor injects a `NoopScopeManager` instead of the `ThreadLocalScopeManager`.

This commit brings the Propagator constructor closer into line with the default
values for this mock.

cc: @yurishkuro

Signed-off-by: Nate Hart <nhart@tableau.com>