### PR TITLE
Fixes the error message for the TextMapExtractAdapter to refer to the…

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapExtractAdapter.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapExtractAdapter.java
@@ -40,6 +40,6 @@ public final class TextMapExtractAdapter implements TextMap {
 
     @Override
     public void put(String key, String value) {
-        throw new UnsupportedOperationException("TextMapInjectAdapter should only be used with Tracer.extract()");
+        throw new UnsupportedOperationException("TextMapExtractAdapter should only be used with Tracer.extract()");
     }
 }


### PR DESCRIPTION
The current message for the TextMapExtractAdapter is currently referring to the wrong class. This PR changes it from TextMapInjectAdapter to TextMapExtractAdapter. 