### PR TITLE
Document that Tracer#extract can return null

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -91,14 +91,14 @@ public interface Tracer {
      * </code></pre>
      *
      * If the span serialized state is invalid (corrupt, wrong version, etc) inside the carrier this will result in an
-     * IllegalArgumentException.
+     * IllegalArgumentException. If the span serialized state is missing the method returns null.
      *
      * @param <C> the carrier type, which also parametrizes the Format.
      * @param format the Format of the carrier
      * @param carrier the carrier for the SpanContext state. All Tracer.extract() implementations must support
      *                io.opentracing.propagation.TextMap and java.nio.ByteBuffer.
      *
-     * @return the SpanContext instance holding context to create a Span.
+     * @return the SpanContext instance holding context to create a Span, null otherwise.
      *
      * @see io.opentracing.propagation.Format
      * @see io.opentracing.propagation.Format.Builtin


### PR DESCRIPTION
See https://github.com/opentracing/opentracing-java/issues/168

https://github.com/opentracing/opentracing-java/pull/203

There are two proposed changes in the above issue:
- Documenting that Tracer#extract can return null (many tracer impls are already doing this)
- Adding `@Nullable` annotation to `extract` to assist static checkers

This PR only addresses the doc change. The annotation will be proposed in a separate PR.