### PR TITLE
Add nullable annotation to Tracer#extract

### DIFF
--- a/opentracing-api/pom.xml
+++ b/opentracing-api/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <scope>provided</scope>
+            <optional>true</optional><!-- needed only for annotations -->
         </dependency>
     </dependencies>
 

--- a/opentracing-api/pom.xml
+++ b/opentracing-api/pom.xml
@@ -31,7 +31,16 @@
         <main.basedir>${project.basedir}/..</main.basedir>
         <main.java.version>1.6</main.java.version>
         <main.signature.artifact>java16</main.signature.artifact>
+        <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -15,6 +15,8 @@ package io.opentracing;
 
 import io.opentracing.propagation.Format;
 
+import javax.annotation.Nullable;
+
 /**
  * Tracer is a simple, thin interface for Span creation and propagation across arbitrary transports.
  */
@@ -103,6 +105,7 @@ public interface Tracer {
      * @see io.opentracing.propagation.Format
      * @see io.opentracing.propagation.Format.Builtin
      */
+    @Nullable
     <C> SpanContext extract(Format<C> format, C carrier);
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <mockito.version>1.10.19</mockito.version>
         <awaitility.version>3.0.0</awaitility.version>
         <logback.version>1.2.3</logback.version>
+        <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
 
         <animal-sniffer-maven-plugin.version>1.15</animal-sniffer-maven-plugin.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
@@ -163,6 +164,13 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-all</artifactId>
                 <version>${mockito.version}</version>
+            </dependency>
+
+            <dependency>
+              <groupId>com.google.code.findbugs</groupId>
+              <artifactId>jsr305</artifactId>
+              <version>${findbugs-jsr305.version}</version>
+              <optional>true</optional><!-- needed only for annotations -->
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
* Add findbugs annotations as optional dependency (chosen due to widespread IDE support and java6 support)
* Add `@Nullable` annotation to `Tracer#extract`

Closes https://github.com/opentracing/opentracing-java/issues/168

Closes https://github.com/opentracing/opentracing-java/pull/203

![image](https://user-images.githubusercontent.com/31153155/42110978-c5308c9e-7b97-11e8-805e-1d1337d5e28b.png)