### PR TITLE
Remove finish span on close

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Scope.java
+++ b/opentracing-api/src/main/java/io/opentracing/Scope.java
@@ -37,6 +37,7 @@ public interface Scope extends Closeable {
     void close();
 
     /**
+     * @deprecated
      * @return the {@link Span} that's been scoped by this {@link Scope}
      */
     Span span();

--- a/opentracing-api/src/main/java/io/opentracing/Scope.java
+++ b/opentracing-api/src/main/java/io/opentracing/Scope.java
@@ -26,8 +26,9 @@ import java.io.Closeable;
  */
 public interface Scope extends Closeable {
     /**
-     * Mark the end of the active period for the current thread and {@link Scope},
-     * updating the {@link ScopeManager#active()} in the process.
+     * Mark the end of the active period for the current context (usually a thread)
+     * and {@link Scope}, updating {@link ScopeManager#active()} and {@link ScopeManager#activeSpan()}
+     * in the process.
      *
      * <p>
      * NOTE: Calling {@link #close} more than once on a single {@link Scope} instance leads to undefined
@@ -37,8 +38,11 @@ public interface Scope extends Closeable {
     void close();
 
     /**
-     * @deprecated
+     * @deprecated use {@link Span} directly or access it through {@link ScopeManager#activeSpan()}
+     * Return the corresponding active {@link Span} for this instance.
+     *
      * @return the {@link Span} that's been scoped by this {@link Scope}
      */
+    @Deprecated
     Span span();
 }

--- a/opentracing-api/src/main/java/io/opentracing/ScopeManager.java
+++ b/opentracing-api/src/main/java/io/opentracing/ScopeManager.java
@@ -26,23 +26,37 @@ import io.opentracing.Tracer.SpanBuilder;
 public interface ScopeManager {
 
     /**
-     * @deprecated use {@link #activate} instead.
-     * Make a {@link Span} instance active.
+     * Set the specified {@link Span} as the active instance for the current
+     * context (usually a thread).
      *
-     * @param span the {@link Span} that should become the {@link #active()}
-     * @param finishSpanOnClose whether span should automatically be finished when {@link Scope#close()} is called
-     * @return a {@link Scope} instance to control the end of the active period for the {@link Span}. It is a
-     * programming error to neglect to call {@link Scope#close()} on the returned instance.
-     */
-    @Deprecated
-    Scope activate(Span span, boolean finishSpanOnClose);
-
-    /**
-     * Make a {@link Span} instance active.
+     * <p>
+     * The returned {@link Scope} represents the active state for the span.
+     * Once its active period is due, {@link Scope#close()} ought to be called.
+     * To ease this operation, {@link Scope} supports try-with-resources.
+     * Observe the span will not be automatically finished when {@link Scope#close()}
+     * is called.
      *
-     * The span will not be automatically finished when {@link Scope#close()} is called.
+     * <p>
+     * This {@link Scope} instance can be accessed at any time through {@link #active()},
+     * in case it is not possible for the user to store it (when used through middleware
+     * or start/finish event hooks, for example). The corresponding {@link Span} can be
+     * accessed through {@link #activeSpan()} likewise.
      *
-     * @param span the {@link Span} that should become the {@link #active()}
+     * <p>
+     * Usage:
+     * <pre><code>
+     *     Span span = tracer.buildSpan("...").start();
+     *     try (Scope scope = tracer.scopeManager().activate(span)) {
+     *         span.setTag("...", "...");
+     *         ...
+     *     } catch (Exception e) {
+     *         span.log(...);
+     *     } finally {
+     *         span.finish(); // Optionally finish the Span.
+     *     }
+     * </code></pre>
+     *
+     * @param span the {@link Span} that should become the {@link #activeSpan()}
      * @return a {@link Scope} instance to control the end of the active period for the {@link Span}. It is a
      * programming error to neglect to call {@link Scope#close()} on the returned instance.
      */
@@ -53,10 +67,12 @@ public interface ScopeManager {
      * {@link Span}.
      *
      * <p>
-     * If there is an {@link Scope non-null scope}, its wrapped {@link Span} becomes an implicit parent
-     * (as {@link References#CHILD_OF} reference) of any
-     * newly-created {@link Span} at {@link Tracer.SpanBuilder#startActive(boolean)} or {@link SpanBuilder#start()}
-     * time rather than at {@link Tracer#buildSpan(String)} time.
+     * Observe that {@link Scope} is expected to be used only in the same thread where it was
+     * created, and thus should not be passed across threads.
+     *
+     * <p>
+     * Because both {@link #active()} and {@link #activeSpan()} reference the current
+     * the active state, they both will be either null or non-null.
      *
      * @return the {@link Scope active scope}, or null if none could be found.
      */
@@ -68,10 +84,38 @@ public interface ScopeManager {
      * <p>
      * If there is an {@link Span non-null active span}, it becomes an implicit parent
      * (as {@link References#CHILD_OF} reference) of any
-     * newly-created {@link Span} at {@link Tracer.SpanBuilder#startActive(boolean)} or {@link SpanBuilder#start()}
+     * newly-created {@link Span} at {@link SpanBuilder#start()} or {@link Tracer.SpanBuilder#startActive(boolean)}
      * time rather than at {@link Tracer#buildSpan(String)} time.
+     *
+     * <p>
+     * Because both {@link #active()} and {@link #activeSpan()} reference the current
+     * the active state, they both will be either null or non-null.
      *
      * @return the {@link Span active span}, or null if none could be found.
      */
     Span activeSpan();
+
+    /**
+     * @deprecated use {@link #activate(Span)} instead.
+     * Set the specified {@link Span} as the active instance for the current
+     * context (usually a thread).
+     *
+     * <p>
+     * Finishing the {@link Span} upon {@link Scope#close()} is discouraged,
+     * as reporting errors becomes impossible:
+     * <pre><code>
+     *     try (Scope scope = tracer.scopeManager().activate(span, true)) {
+     *     } catch (Exception e) {
+     *         // Not possible to report errors, as
+     *         // the span has been already finished.
+     *     }
+     * </code></pre>
+     *
+     * @param span the {@link Span} that should become the {@link #activeSpan()}
+     * @param finishSpanOnClose whether span should automatically be finished when {@link Scope#close()} is called
+     * @return a {@link Scope} instance to control the end of the active period for the {@link Span}. It is a
+     * programming error to neglect to call {@link Scope#close()} on the returned instance.
+     */
+    @Deprecated
+    Scope activate(Span span, boolean finishSpanOnClose);
 }

--- a/opentracing-api/src/main/java/io/opentracing/ScopeManager.java
+++ b/opentracing-api/src/main/java/io/opentracing/ScopeManager.java
@@ -52,7 +52,9 @@ public interface ScopeManager {
      *     } catch (Exception e) {
      *         span.log(...);
      *     } finally {
-     *         span.finish(); // Optionally finish the Span.
+     *         // Optionally finish the Span if the operation it represents
+     *         // is logically completed at this point.
+     *         span.finish();
      *     }
      * </code></pre>
      *
@@ -72,7 +74,7 @@ public interface ScopeManager {
      *
      * <p>
      * Because both {@link #active()} and {@link #activeSpan()} reference the current
-     * the active state, they both will be either null or non-null.
+     * active state, they both will be either null or non-null.
      *
      * @return the {@link Scope active scope}, or null if none could be found.
      */
@@ -82,14 +84,8 @@ public interface ScopeManager {
      * Return the currently active {@link Span}.
      *
      * <p>
-     * If there is an {@link Span non-null active span}, it becomes an implicit parent
-     * (as {@link References#CHILD_OF} reference) of any
-     * newly-created {@link Span} at {@link SpanBuilder#start()} or {@link Tracer.SpanBuilder#startActive(boolean)}
-     * time rather than at {@link Tracer#buildSpan(String)} time.
-     *
-     * <p>
      * Because both {@link #active()} and {@link #activeSpan()} reference the current
-     * the active state, they both will be either null or non-null.
+     * active state, they both will be either null or non-null.
      *
      * @return the {@link Span active span}, or null if none could be found.
      */

--- a/opentracing-api/src/main/java/io/opentracing/ScopeManager.java
+++ b/opentracing-api/src/main/java/io/opentracing/ScopeManager.java
@@ -49,8 +49,8 @@ public interface ScopeManager {
     Scope activate(Span span);
 
     /**
-     * Return the currently active {@link Scope} which can be used to access the currently active
-     * {@link Scope#span()}.
+     * Return the currently active {@link Scope} which can be used to deactivate the currently active
+     * {@link Span}.
      *
      * <p>
      * If there is an {@link Scope non-null scope}, its wrapped {@link Span} becomes an implicit parent
@@ -61,4 +61,17 @@ public interface ScopeManager {
      * @return the {@link Scope active scope}, or null if none could be found.
      */
     Scope active();
+
+    /**
+     * Return the currently active {@link Span}.
+     *
+     * <p>
+     * If there is an {@link Span non-null active span}, it becomes an implicit parent
+     * (as {@link References#CHILD_OF} reference) of any
+     * newly-created {@link Span} at {@link Tracer.SpanBuilder#startActive(boolean)} or {@link SpanBuilder#start()}
+     * time rather than at {@link Tracer#buildSpan(String)} time.
+     *
+     * @return the {@link Span active span}, or null if none could be found.
+     */
+    Span activeSpan();
 }

--- a/opentracing-api/src/main/java/io/opentracing/ScopeManager.java
+++ b/opentracing-api/src/main/java/io/opentracing/ScopeManager.java
@@ -26,6 +26,7 @@ import io.opentracing.Tracer.SpanBuilder;
 public interface ScopeManager {
 
     /**
+     * @deprecated use {@link #activate} instead.
      * Make a {@link Span} instance active.
      *
      * @param span the {@link Span} that should become the {@link #active()}
@@ -33,7 +34,19 @@ public interface ScopeManager {
      * @return a {@link Scope} instance to control the end of the active period for the {@link Span}. It is a
      * programming error to neglect to call {@link Scope#close()} on the returned instance.
      */
+    @Deprecated
     Scope activate(Span span, boolean finishSpanOnClose);
+
+    /**
+     * Make a {@link Span} instance active.
+     *
+     * The span will not be automatically finished when {@link Scope#close()} is called.
+     *
+     * @param span the {@link Span} that should become the {@link #active()}
+     * @return a {@link Scope} instance to control the end of the active period for the {@link Span}. It is a
+     * programming error to neglect to call {@link Scope#close()} on the returned instance.
+     */
+    Scope activate(Span span);
 
     /**
      * Return the currently active {@link Scope} which can be used to access the currently active

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -26,10 +26,17 @@ public interface Tracer {
     ScopeManager scopeManager();
 
     /**
-     * @return the active {@link Span}. This is a shorthand for Tracer.scopeManager().active().span(),
-     * and null will be returned if {@link Scope#active()} is null.
+     * @return the active {@link Span}. This is a shorthand for Tracer.scopeManager().activeSpan().
      */
     Span activeSpan();
+
+    /**
+     * Make a {@link Span} instance active. This is a shorthand for Tracer.scopeManager().activate().
+     *
+     * @return a {@link Scope} instance to control the end of the active period for the {@link Span}. It is a
+     * programming error to neglect to call {@link Scope#close()} on the returned instance.
+     */
+    Scope activateSpan(Span span);
 
     /**
      * Return a new SpanBuilder for a Span with the given `operationName`.
@@ -183,6 +190,7 @@ public interface Tracer {
         Scope startActive(boolean finishSpanOnClose);
 
         /**
+         * @deprecated
          * Returns a newly started and activated {@link Scope}.
          *
          * The span will not be automatically finished when {@link Scope#close()} is called.

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -166,16 +166,40 @@ public interface Tracer {
         SpanBuilder withStartTimestamp(long microseconds);
 
         /**
+         * @deprecated use {@link #startActive} instead.
          * Returns a newly started and activated {@link Scope}.
          *
          * <p>
-         * The returned {@link Scope} supports try-with-resources. For example:
+         * Note: {@link SpanBuilder#startActive(boolean)} is a shorthand for
+         * {@code tracer.scopeManager().activate(spanBuilder.start(), finishSpanOnClose)}.
+         *
+         * @param finishSpanOnClose whether span should automatically be finished when {@link Scope#close()} is called
+         * @return a {@link Scope}, already registered via the {@link ScopeManager}
+         *
+         * @see ScopeManager
+         * @see Scope
+         */
+        @Deprecated
+        Scope startActive(boolean finishSpanOnClose);
+
+        /**
+         * Returns a newly started and activated {@link Scope}.
+         *
+         * The span will not be automatically finished when {@link Scope#close()} is called.
+         *
+         * <p>
+         * The returned {@link Scope} supports try-with-resources, but is usually
+         * used like this:
          * <pre><code>
-         *     try (Scope scope = tracer.buildSpan("...").startActive(true)) {
+         *     Scope scope = null;
+         *     try {
+         *         scope = tracer.buildSpan("...").startActive();
          *         // (Do work)
          *         scope.span().setTag( ... );  // etc, etc
+         *     } finally {
+         *         scope.span().finish(); // Finish the newly created Span.
+         *         scope.close(); // Deactivate the Scope.
          *     }
-         *     // Span does finishes automatically only when 'finishSpanOnClose' is true
          * </code></pre>
          *
          * <p>
@@ -190,16 +214,15 @@ public interface Tracer {
          * {@link SpanBuilder#start()} or {@link SpanBuilder#startActive} is invoked.
          *
          * <p>
-         * Note: {@link SpanBuilder#startActive(boolean)} is a shorthand for
-         * {@code tracer.scopeManager().activate(spanBuilder.start(), finishSpanOnClose)}.
+         * Note: {@link SpanBuilder#startActive()} is a shorthand for
+         * {@code tracer.scopeManager().activate(spanBuilder.start())}.
          *
-         * @param finishSpanOnClose whether span should automatically be finished when {@link Scope#close()} is called
          * @return a {@link Scope}, already registered via the {@link ScopeManager}
          *
          * @see ScopeManager
          * @see Scope
          */
-        Scope startActive(boolean finishSpanOnClose);
+        Scope startActive();
 
         /**
          * @deprecated use {@link #start} or {@link #startActive} instead.

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -35,7 +35,8 @@ public interface Tracer {
      * This is a shorthand for {@code Tracer.scopeManager().activate(span)}.
      *
      * @return a {@link Scope} instance to control the end of the active period for the {@link Span}. It is a
-     * programming error to neglect to call {@link Scope#close()} on the returned instance.
+     * programming error to neglect to call {@link Scope#close()} on the returned instance,
+     * and it may lead to memory leaks as the {@link Scope} may remain in the thread-local stack.
      */
     Scope activateSpan(Span span);
 
@@ -49,7 +50,8 @@ public interface Tracer {
      *   Tracer tracer = ...
      *
      *   // Note: if there is a `tracer.activeSpan()` instance, it will be used as the target
-     *   // of an implicit CHILD_OF Reference when `start()` is invoked.
+     *   // of an implicit CHILD_OF Reference when `start()` is invoked,
+     *   // unless another Span reference is explicitly provided to the builder.
      *   Span span = tracer.buildSpan("HandleHTTPRequest")
      *                     .asChildOf(rpcSpanContext)  // an explicit parent
      *                     .withTag("user_agent", req.UserAgent)

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -275,11 +275,6 @@ public class MockTracer implements Tracer {
         }
 
         @Override
-        public Scope startActive() {
-            return MockTracer.this.scopeManager().activate(this.startManual());
-        }
-
-        @Override
         public MockSpan start() {
             return startManual();
         }

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -270,6 +270,11 @@ public class MockTracer implements Tracer {
         }
 
         @Override
+        public Scope startActive() {
+            return MockTracer.this.scopeManager().activate(this.startManual());
+        }
+
+        @Override
         public MockSpan start() {
             return startManual();
         }

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -188,6 +188,11 @@ public class MockTracer implements Tracer {
         return scope == null ? null : scope.span();
     }
 
+    @Override
+    public Scope activateSpan(Span span) {
+        return this.scopeManager.activate(span);
+    }
+
     synchronized void appendFinishedSpan(MockSpan mockSpan) {
         this.finishedSpans.add(mockSpan);
         this.onSpanFinished(mockSpan);

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -209,6 +209,23 @@ public class MockTracerTest {
 
         Scope scope = null;
         try {
+            scope = mockTracer.buildSpan("foo").startActive();
+            Assert.assertEquals(mockTracer.scopeManager().active().span(), mockTracer.activeSpan());
+        } finally {
+            scope.close();
+        }
+
+        Assert.assertNull(mockTracer.activeSpan());
+        Assert.assertTrue(mockTracer.finishedSpans().isEmpty());
+    }
+
+    @Test
+    public void testActiveSpanFinish() {
+        MockTracer mockTracer = new MockTracer();
+        Assert.assertNull(mockTracer.activeSpan());
+
+        Scope scope = null;
+        try {
             scope = mockTracer.buildSpan("foo").startActive(true);
             Assert.assertEquals(mockTracer.scopeManager().active().span(), mockTracer.activeSpan());
         } finally {
@@ -216,6 +233,7 @@ public class MockTracerTest {
         }
 
         Assert.assertNull(mockTracer.activeSpan());
+        Assert.assertFalse(mockTracer.finishedSpans().isEmpty());
     }
 
     @Test
@@ -304,7 +322,7 @@ public class MockTracerTest {
     @Test
     public void testDefaultConstructor() {
         MockTracer mockTracer = new MockTracer();
-        Scope scope = mockTracer.buildSpan("foo").startActive(true);
+        Scope scope = mockTracer.buildSpan("foo").startActive();
         assertEquals(scope, mockTracer.scopeManager().active());
 
         Map<String, String> propag = new HashMap<>();

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -207,12 +207,9 @@ public class MockTracerTest {
         MockTracer mockTracer = new MockTracer();
         Assert.assertNull(mockTracer.activeSpan());
 
-        Scope scope = null;
-        try {
-            scope = mockTracer.buildSpan("foo").startActive();
+        Span span = mockTracer.buildSpan("foo").start();
+        try (Scope scope = mockTracer.activateSpan(span)) {
             Assert.assertEquals(mockTracer.scopeManager().activeSpan(), mockTracer.activeSpan());
-        } finally {
-            scope.close();
         }
 
         Assert.assertNull(mockTracer.activeSpan());

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -210,7 +210,7 @@ public class MockTracerTest {
         Scope scope = null;
         try {
             scope = mockTracer.buildSpan("foo").startActive();
-            Assert.assertEquals(mockTracer.scopeManager().active().span(), mockTracer.activeSpan());
+            Assert.assertEquals(mockTracer.scopeManager().activeSpan(), mockTracer.activeSpan());
         } finally {
             scope.close();
         }
@@ -227,7 +227,7 @@ public class MockTracerTest {
         Scope scope = null;
         try {
             scope = mockTracer.buildSpan("foo").startActive(true);
-            Assert.assertEquals(mockTracer.scopeManager().active().span(), mockTracer.activeSpan());
+            Assert.assertEquals(mockTracer.scopeManager().activeSpan(), mockTracer.activeSpan());
         } finally {
             scope.close();
         }
@@ -322,8 +322,10 @@ public class MockTracerTest {
     @Test
     public void testDefaultConstructor() {
         MockTracer mockTracer = new MockTracer();
-        Scope scope = mockTracer.buildSpan("foo").startActive();
+        Span span = mockTracer.buildSpan("foo").start();
+        Scope scope = mockTracer.activateSpan(span);
         assertEquals(scope, mockTracer.scopeManager().active());
+        assertEquals(span, mockTracer.scopeManager().activeSpan());
 
         Map<String, String> propag = new HashMap<>();
         mockTracer.inject(scope.span().context(), Format.Builtin.TEXT_MAP, new TextMapInjectAdapter(propag));

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
@@ -44,6 +44,11 @@ class NoopScopeManagerImpl implements NoopScopeManager {
         return NoopScope.INSTANCE;
     }
 
+    @Override
+    public Span activeSpan() {
+        return NoopSpan.INSTANCE;
+    }
+
     static class NoopScopeImpl implements NoopScopeManager.NoopScope {
         @Override
         public void close() {}

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
@@ -35,6 +35,11 @@ class NoopScopeManagerImpl implements NoopScopeManager {
     }
 
     @Override
+    public Scope activate(Span span) {
+        return NoopScope.INSTANCE;
+    }
+
+    @Override
     public Scope active() {
         return NoopScope.INSTANCE;
     }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
@@ -71,6 +71,11 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
     }
 
     @Override
+    public Scope startActive() {
+        return NoopScopeManager.NoopScope.INSTANCE;
+    }
+
+    @Override
     public Span start() {
         return startManual();
     }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
@@ -71,11 +71,6 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
     }
 
     @Override
-    public Scope startActive() {
-        return NoopScopeManager.NoopScope.INSTANCE;
-    }
-
-    @Override
     public Span start() {
         return startManual();
     }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
@@ -14,6 +14,7 @@
 package io.opentracing.noop;
 
 import io.opentracing.ScopeManager;
+import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -33,6 +34,11 @@ final class NoopTracerImpl implements NoopTracer {
     @Override
     public Span activeSpan() {
         return NoopSpanImpl.INSTANCE;
+    }
+
+    @Override
+    public Scope activateSpan(Span span) {
+        return NoopScopeManager.NoopScope.INSTANCE;
     }
 
     @Override

--- a/opentracing-testbed/README.md
+++ b/opentracing-testbed/README.md
@@ -13,6 +13,7 @@ It shows continuation as a solution to finish span when last action is completed
 - [actor_propagation](src/test/java/io/opentracing/testbed/actor_propagation) - tracing for blocking and non-blocking actor based tracing
 - [client_server](src/test/java/io/opentracing/testbed/client_server) - typical client-server example
 - [common_request_handler](src/test/java/io/opentracing/testbed/common_request_handler) - one request handler for all requests
+- [error_reporting](src/test/java/io/opentracing/testbed/error_reporting) - a few common cases of error reporting
 - [late_span_finish](src/test/java/io/opentracing/testbed/late_span_finish) - late parent span finish
 - [listener_per_request](src/test/java/io/opentracing/testbed/listener_per_request) - one listener per request
 - [multiple_callbacks](src/test/java/io/opentracing/testbed/multiple_callbacks) - many callbacks spawned at the same time

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/activate_deactivate/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/activate_deactivate/README.md
@@ -8,7 +8,7 @@ This example shows the usage of the `Continuation` concept (now part of the `Aut
 return new Thread(new Runnable() {
     @Override
     public void run() {
-	try (Scope scope = tracer.buildSpan("parent").startActive(false)) {
+	try (Scope scope = tracer.buildSpan("parent").startActive()) {
 	    Runnable action = new RunnableAction((AutoFinishScope)scope);
 	    Runnable action2 = new RunnableAction((AutoFinishScope)scope);
 

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/activate_deactivate/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/activate_deactivate/README.md
@@ -8,7 +8,8 @@ This example shows the usage of the `Continuation` concept (now part of the `Aut
 return new Thread(new Runnable() {
     @Override
     public void run() {
-	try (Scope scope = tracer.buildSpan("parent").startActive()) {
+	Span span = tracer.buildSpan("parent").start();
+	try (Scope scope = tracer.activateSpan(span)) {
 	    Runnable action = new RunnableAction((AutoFinishScope)scope);
 	    Runnable action2 = new RunnableAction((AutoFinishScope)scope);
 

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/activate_deactivate/ScheduledActionsTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/activate_deactivate/ScheduledActionsTest.java
@@ -14,6 +14,7 @@
 package io.opentracing.testbed.activate_deactivate;
 
 import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.util.AutoFinishScope;
 import io.opentracing.util.AutoFinishScopeManager;
 import io.opentracing.mock.MockSpan;
@@ -89,7 +90,8 @@ public class ScheduledActionsTest {
             @Override
             public void run() {
                 logger.info("Entry thread started");
-                try (Scope scope = tracer.buildSpan("parent").startActive()) {
+                Span span = tracer.buildSpan("parent").start();
+                try (Scope scope = tracer.activateSpan(span)) {
                     Runnable action = new RunnableAction((AutoFinishScope)scope);
 
                     // Action is executed at some time and we are not able to check status
@@ -108,7 +110,8 @@ public class ScheduledActionsTest {
             @Override
             public void run() {
                 logger.info("Entry thread 2x started");
-                try (Scope scope = tracer.buildSpan("parent").startActive()) {
+                Span span = tracer.buildSpan("parent").start();
+                try (Scope scope = tracer.activateSpan(span)) {
                     Runnable action = new RunnableAction((AutoFinishScope)scope);
                     Runnable action2 = new RunnableAction((AutoFinishScope)scope);
 

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/activate_deactivate/ScheduledActionsTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/activate_deactivate/ScheduledActionsTest.java
@@ -89,7 +89,7 @@ public class ScheduledActionsTest {
             @Override
             public void run() {
                 logger.info("Entry thread started");
-                try (Scope scope = tracer.buildSpan("parent").startActive(false)) {
+                try (Scope scope = tracer.buildSpan("parent").startActive()) {
                     Runnable action = new RunnableAction((AutoFinishScope)scope);
 
                     // Action is executed at some time and we are not able to check status
@@ -108,7 +108,7 @@ public class ScheduledActionsTest {
             @Override
             public void run() {
                 logger.info("Entry thread 2x started");
-                try (Scope scope = tracer.buildSpan("parent").startActive(false)) {
+                try (Scope scope = tracer.buildSpan("parent").startActive()) {
                     Runnable action = new RunnableAction((AutoFinishScope)scope);
                     Runnable action2 = new RunnableAction((AutoFinishScope)scope);
 

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/active_span_replacement/ActiveSpanReplacementTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/active_span_replacement/ActiveSpanReplacementTest.java
@@ -44,9 +44,10 @@ public class ActiveSpanReplacementTest {
     @Test
     public void test() throws Exception {
         // Start an isolated task and query for its result in another task/thread
-        try (Scope scope = tracer.buildSpan("initial").startActive()) {
+        Span span = tracer.buildSpan("initial").start();
+        try (Scope scope = tracer.scopeManager().activate(span)) {
             // Explicitly pass a Span to be finished once a late calculation is done.
-            submitAnotherTask(scope.span());
+            submitAnotherTask(span);
         }
 
         await().atMost(15, TimeUnit.SECONDS).until(finishedSpansSize(tracer), equalTo(3));

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/active_span_replacement/ActiveSpanReplacementTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/active_span_replacement/ActiveSpanReplacementTest.java
@@ -44,7 +44,7 @@ public class ActiveSpanReplacementTest {
     @Test
     public void test() throws Exception {
         // Start an isolated task and query for its result in another task/thread
-        try (Scope scope = tracer.buildSpan("initial").startActive(false)) {
+        try (Scope scope = tracer.buildSpan("initial").startActive()) {
             // Explicitly pass a Span to be finished once a late calculation is done.
             submitAnotherTask(scope.span());
         }
@@ -74,17 +74,25 @@ public class ActiveSpanReplacementTest {
             @Override
             public void run() {
                 // Create a new Span for this task
-                try (Scope taskScope = tracer.buildSpan("task").startActive(true)) {
+                Span taskSpan = tracer.buildSpan("task").start();
+                try (Scope scope = tracer.scopeManager().activate(taskSpan)) {
 
                     // Simulate work strictly related to the initial Span
                     // and finish it.
-                    try (Scope initialScope = tracer.scopeManager().activate(initialSpan, true)) {
+                    try (Scope initialScope = tracer.scopeManager().activate(initialSpan)) {
                         sleep(50);
+                    } finally {
+                        initialSpan.finish();
                     }
 
                     // Restore the span for this task and create a subspan
-                    try (Scope subTaskScope = tracer.buildSpan("subtask").startActive(true)) {
+                    Span subTaskSpan = tracer.buildSpan("subtask").start();
+                    try (Scope subTaskScope = tracer.scopeManager().activate(subTaskSpan)) {
+                    } finally {
+                        subTaskSpan.finish();
                     }
+                } finally {
+                    taskSpan.finish();
                 }
             }
         });

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/active_span_replacement/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/active_span_replacement/README.md
@@ -4,11 +4,18 @@ This example shows a `Span` being created and then passed to an asynchronous tas
 
 ```java
 // Create a new Span for this task
-try (Scope taskScope = tracer.buildSpan("task").startActive(true)) {
+Span taskSpan = tracer.buildSpan("task").start();
+try (Scope scope = tracer.scopeManager().activate(taskSpan)) {
 
     // Simulate work strictly related to the initial Span
     // and finish it.
-    try (Scope initialScope = tracer.scopeManager().activate(initialSpan, true)) {
+    try (Scope initialScope = tracer.scopeManager().activate(initialSpan)) {
+    } finally {
+      initialSpan.finish();
     }
+
+    // Continue doing tasks under taskSpan
+} finally {
+  taskSpan.finish();
 }
 ```

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/actor_propagation/ActorPropagationTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/actor_propagation/ActorPropagationTest.java
@@ -55,14 +55,17 @@ public class ActorPropagationTest {
   public void testActorTell() {
     try (Actor actor = new Actor(tracer, phaser)) {
       phaser.register();
-      try (Scope parent =
-          tracer
-              .buildSpan("actorTell")
-              .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)
-              .withTag(Tags.COMPONENT.getKey(), "example-actor")
-              .startActive(true)) {
+      Scope parent = tracer
+          .buildSpan("actorTell")
+          .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)
+          .withTag(Tags.COMPONENT.getKey(), "example-actor")
+          .startActive();
+      try {
         actor.tell("my message 1");
         actor.tell("my message 2");
+      } finally {
+          parent.close();
+          parent.span().finish();
       }
       phaser.arriveAndAwaitAdvance(); // child tracer started
       assertThat(tracer.finishedSpans().size()).isEqualTo(1); // Parent should be reported
@@ -91,14 +94,17 @@ public class ActorPropagationTest {
       phaser.register();
       Future<String> future1;
       Future<String> future2;
-      try (Scope parent =
-          tracer
-              .buildSpan("actorAsk")
-              .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)
-              .withTag(Tags.COMPONENT.getKey(), "example-actor")
-              .startActive(true)) {
+      Scope parent = tracer
+          .buildSpan("actorAsk")
+          .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)
+          .withTag(Tags.COMPONENT.getKey(), "example-actor")
+          .startActive();
+      try {
         future1 = actor.ask("my message 1");
         future2 = actor.ask("my message 2");
+      } finally {
+        parent.close();
+        parent.span().finish();
       }
       phaser.arriveAndAwaitAdvance(); // child tracer started
       assertThat(tracer.finishedSpans().size()).isEqualTo(1);

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/actor_propagation/ActorPropagationTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/actor_propagation/ActorPropagationTest.java
@@ -14,6 +14,7 @@
 package io.opentracing.testbed.actor_propagation;
 
 import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.mock.MockTracer.Propagator;
@@ -55,17 +56,16 @@ public class ActorPropagationTest {
   public void testActorTell() {
     try (Actor actor = new Actor(tracer, phaser)) {
       phaser.register();
-      Scope parent = tracer
+      Span parent = tracer
           .buildSpan("actorTell")
           .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)
           .withTag(Tags.COMPONENT.getKey(), "example-actor")
-          .startActive();
-      try {
+          .start();
+      try (Scope scope = tracer.activateSpan(parent)) {
         actor.tell("my message 1");
         actor.tell("my message 2");
       } finally {
-          parent.close();
-          parent.span().finish();
+        parent.finish();
       }
       phaser.arriveAndAwaitAdvance(); // child tracer started
       assertThat(tracer.finishedSpans().size()).isEqualTo(1); // Parent should be reported
@@ -94,17 +94,16 @@ public class ActorPropagationTest {
       phaser.register();
       Future<String> future1;
       Future<String> future2;
-      Scope parent = tracer
+      Span span = tracer
           .buildSpan("actorAsk")
           .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)
           .withTag(Tags.COMPONENT.getKey(), "example-actor")
-          .startActive();
-      try {
+          .start();
+      try (Scope scope = tracer.activateSpan(span)) {
         future1 = actor.ask("my message 1");
         future2 = actor.ask("my message 2");
       } finally {
-        parent.close();
-        parent.span().finish();
+        span.finish();
       }
       phaser.arriveAndAwaitAdvance(); // child tracer started
       assertThat(tracer.finishedSpans().size()).isEqualTo(1);

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/actor_propagation/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/actor_propagation/README.md
@@ -12,15 +12,17 @@ This example shows `Span` usage with `Scala` frameworks using the `Actor` paradi
         new Runnable() {
           @Override
           public void run() {
-            try (Scope child =
-                tracer
-                    .buildSpan("received")
-                    .addReference(References.FOLLOWS_FROM, parent.context())
-                    .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER)
-                    .startActive(true)) {
+            Scope child = tracer
+                .buildSpan("received")
+                .addReference(References.FOLLOWS_FROM, parent.context())
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER)
+                .startActive();
+            try {
               ...
+            } finally {
+              child.close();
+              child.span().finish();
             }
           }
         });
-  }
 ```

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Client.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Client.java
@@ -14,6 +14,7 @@
 package io.opentracing.testbed.client_server;
 
 import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format.Builtin;
 import io.opentracing.propagation.TextMapInjectAdapter;
@@ -34,17 +35,15 @@ public class Client {
     public void send() throws InterruptedException {
         Message message = new Message();
 
-        Scope scope = null;
-        try {
-            scope = tracer.buildSpan("send")
-                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
-                .withTag(Tags.COMPONENT.getKey(), "example-client")
-                .startActive();
-            tracer.inject(scope.span().context(), Builtin.TEXT_MAP, new TextMapInjectAdapter(message));
+        Span span = tracer.buildSpan("send")
+            .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
+            .withTag(Tags.COMPONENT.getKey(), "example-client")
+            .start();
+        try (Scope scope = tracer.activateSpan(span)) {
+            tracer.inject(span.context(), Builtin.TEXT_MAP, new TextMapInjectAdapter(message));
             queue.put(message);
         } finally {
-            scope.close();
-            scope.span().finish();
+            span.finish();
         }
     }
 }

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Client.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Client.java
@@ -34,13 +34,17 @@ public class Client {
     public void send() throws InterruptedException {
         Message message = new Message();
 
-        try (Scope scope = tracer.buildSpan("send")
+        Scope scope = null;
+        try {
+            scope = tracer.buildSpan("send")
                 .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
                 .withTag(Tags.COMPONENT.getKey(), "example-client")
-                .startActive(true)) {
+                .startActive();
             tracer.inject(scope.span().context(), Builtin.TEXT_MAP, new TextMapInjectAdapter(message));
             queue.put(message);
+        } finally {
+            scope.close();
+            scope.span().finish();
         }
     }
-
 }

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/README.md
@@ -8,12 +8,16 @@ This example shows a `Span` created by a `Client`, which will send a `Message`/`
     public void send() throws InterruptedException {
         Message message = new Message();
 
-        try (Scope scope = tracer.buildSpan("send")
-                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
-                .withTag(Tags.COMPONENT.getKey(), "example-client")
-                .startActive(true)) {
+        Scope scope = tracer.buildSpan("send")
+              .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
+              .withTag(Tags.COMPONENT.getKey(), "example-client")
+              .startActive();
+        try {
             tracer.inject(scope.span().context(), Builtin.TEXT_MAP, new TextMapInjectAdapter(message));
             queue.put(message);
+        } finally {
+            scope.close();
+            scope.span().finish();
         }
     }
 ```

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/README.md
@@ -8,16 +8,15 @@ This example shows a `Span` created by a `Client`, which will send a `Message`/`
     public void send() throws InterruptedException {
         Message message = new Message();
 
-        Scope scope = tracer.buildSpan("send")
-              .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
-              .withTag(Tags.COMPONENT.getKey(), "example-client")
-              .startActive();
-        try {
-            tracer.inject(scope.span().context(), Builtin.TEXT_MAP, new TextMapInjectAdapter(message));
+        Span span = tracer.buildSpan("send")
+            .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
+            .withTag(Tags.COMPONENT.getKey(), "example-client")
+            .start();
+        try (Scope scope = tracer.activateSpan(span)) {
+            tracer.inject(span.context(), Builtin.TEXT_MAP, new TextMapInjectAdapter(message));
             queue.put(message);
         } finally {
-            scope.close();
-            scope.span().finish();
+            span.finish();
         }
     }
 ```

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Server.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Server.java
@@ -34,11 +34,16 @@ public class Server extends Thread {
 
     private void process(Message message) {
         SpanContext context = tracer.extract(Builtin.TEXT_MAP, new TextMapExtractAdapter(message));
-        try (Scope scope = tracer.buildSpan("receive")
+        Scope scope = null;
+        try {
+            scope = tracer.buildSpan("receive")
               .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
               .withTag(Tags.COMPONENT.getKey(), "example-server")
               .asChildOf(context)
-              .startActive(true)) {
+              .startActive();
+        } finally {
+            scope.close();
+            scope.span().finish();
         }
     }
 

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Server.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Server.java
@@ -14,6 +14,7 @@
 package io.opentracing.testbed.client_server;
 
 import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format.Builtin;
@@ -34,16 +35,15 @@ public class Server extends Thread {
 
     private void process(Message message) {
         SpanContext context = tracer.extract(Builtin.TEXT_MAP, new TextMapExtractAdapter(message));
-        Scope scope = null;
-        try {
-            scope = tracer.buildSpan("receive")
-              .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
-              .withTag(Tags.COMPONENT.getKey(), "example-server")
-              .asChildOf(context)
-              .startActive();
+        Span span = tracer.buildSpan("receive")
+          .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+          .withTag(Tags.COMPONENT.getKey(), "example-server")
+          .asChildOf(context)
+          .start();
+
+        try (Scope scope = tracer.activateSpan(span)) {
         } finally {
-            scope.close();
-            scope.span().finish();
+            span.finish();
         }
     }
 

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/common_request_handler/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/common_request_handler/README.md
@@ -16,7 +16,7 @@ Since its methods are not guaranteed to be run in the same thread, activation of
             spanBuilder.asChildOf(parentContext);
         }
 
-        context.put("span", spanBuilder.startManual());
+        context.put("span", spanBuilder.start());
     }
 
     public void afterResponse(Object response, Context context) {

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/common_request_handler/RequestHandler.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/common_request_handler/RequestHandler.java
@@ -57,7 +57,7 @@ public class RequestHandler {
             spanBuilder.asChildOf(parentContext);
         }
 
-        context.put("span", spanBuilder.startManual());
+        context.put("span", spanBuilder.start());
     }
 
     public void afterResponse(Object response, Context context) {

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/error_reporting/ErrorReportingTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/error_reporting/ErrorReportingTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.testbed.error_reporting;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.log.Fields;
+import io.opentracing.tag.Tags;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+import static io.opentracing.testbed.TestUtils.finishedSpansSize;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+
+
+public class ErrorReportingTest {
+
+    private final MockTracer tracer = new MockTracer();
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    /* Very simple error handling **/
+    @Test
+    public void testSimpleError() {
+        Scope scope = tracer.buildSpan("one").startActive();
+        try {
+            throw new RuntimeException("Invalid state");
+        } catch (Exception e) {
+            Tags.ERROR.set(scope.span(), true);
+        } finally {
+            scope.close();
+            scope.span().finish();
+        }
+
+        assertNull(tracer.scopeManager().active());
+
+        List<MockSpan> spans = tracer.finishedSpans();
+        assertEquals(spans.size(), 1);
+        assertEquals(spans.get(0).tags().get(Tags.ERROR.getKey()), true);
+    }
+
+    /* Error handling in a callback capturing/activating the Span */
+    @Test
+    public void testCallbackError() {
+        Span span = tracer.buildSpan("one").start();
+        executor.submit(new Runnable() {
+            @Override
+            public void run() {
+                try (Scope scope = tracer.scopeManager().activate(span)) {
+                    throw new RuntimeException("Invalid state");
+                } catch (Exception exc) {
+                    Tags.ERROR.set(span, true);
+                } finally {
+                    span.finish();
+                }
+            }
+        });
+
+        await().atMost(5, TimeUnit.SECONDS).until(finishedSpansSize(tracer), equalTo(1));
+
+        List<MockSpan> spans = tracer.finishedSpans();
+        assertEquals(spans.size(), 1);
+        assertEquals(spans.get(0).tags().get(Tags.ERROR.getKey()), true);
+    }
+
+    /* Error handling for a max-retries task (such as url fetching).
+     * We log the Exception at each retry. */
+    @Test
+    public void testErrorRecovery() {
+        final int maxRetries = 1;
+        int retries = 0;
+        Object res = null;
+
+        Scope scope = tracer.buildSpan("one").startActive();
+        while (res == null && retries++ < maxRetries) {
+            try {
+                throw new RuntimeException("No url could be fetched");
+            } catch (Exception exc) {
+                scope.span().log(new TreeMap<String, Object>() {{
+                    put(Fields.EVENT, Tags.ERROR);
+                    put(Fields.ERROR_OBJECT, exc);
+                }});
+            }
+        }
+
+        if (res == null) {
+            Tags.ERROR.set(scope.span(), true); // Could not fetch anything.
+        }
+        scope.close();
+        scope.span().finish();
+
+        assertNull(tracer.scopeManager().active());
+
+        List<MockSpan> spans = tracer.finishedSpans();
+        assertEquals(spans.size(), 1);
+        assertEquals(spans.get(0).tags().get(Tags.ERROR.getKey()), true);
+
+        List<MockSpan.LogEntry> logs = spans.get(0).logEntries();
+        assertEquals(logs.size(), maxRetries);
+        assertEquals(logs.get(0).fields().get(Fields.EVENT), Tags.ERROR);
+        assertNotNull(logs.get(0).fields().get(Fields.ERROR_OBJECT));
+    }
+
+    /* Error handling for a mocked layer automatically capturing/activating
+     * the Span for a submitted Runnable. */
+    @Test
+    public void testInstrumentationLayer() {
+        try (Scope scope = tracer.buildSpan("one").startActive()) {
+
+            // ScopedRunnable captures the active Span at this time.
+            executor.submit(new ScopedRunnable(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        throw new RuntimeException("Invalid state");
+                    } catch (Exception exc) {
+                        Tags.ERROR.set(tracer.activeSpan(), true);
+                    } finally {
+                        tracer.activeSpan().finish();
+                    }
+                }
+            }, tracer));
+        }
+
+        await().atMost(5, TimeUnit.SECONDS).until(finishedSpansSize(tracer), equalTo(1));
+
+        List<MockSpan> spans = tracer.finishedSpans();
+        assertEquals(spans.size(), 1);
+        assertEquals(spans.get(0).tags().get(Tags.ERROR.getKey()), true);
+    }
+
+    static class ScopedRunnable implements Runnable {
+        Runnable runnable;
+        Tracer tracer;
+        Span span;
+
+        public ScopedRunnable(Runnable runnable, Tracer tracer) {
+            this.runnable = runnable;
+            this.tracer = tracer;
+            this.span = tracer.activeSpan();
+        }
+
+        public void run() {
+            // No error reporting is done, as we are a simple wrapper.
+            try (Scope scope = tracer.scopeManager().activate(span)) {
+                runnable.run();
+            }
+        }
+    }
+}

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/error_reporting/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/error_reporting/README.md
@@ -1,0 +1,19 @@
+# Error Reporting example.
+
+This example shows a few common error reporting cases, mostly interacting with `Scope` and `Span` propagation. In such cases, at the very least `opentracing.tags.Tag.ERROR` must be set in the `Span`:
+
+```java
+Span span = tracer.buildSpan("one").start();
+executor.submit(new Runnable() {
+    @Override
+    public void run() {
+	try (Scope scope = tracer.scopeManager().activate(span)) {
+	    throw new RuntimeException("Invalid state");
+	} catch (Exception exc) {
+	    Tags.ERROR.set(span, true);
+	} finally {
+	    span.finish();
+	}
+    }
+});
+```

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/error_reporting/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/error_reporting/README.md
@@ -7,7 +7,7 @@ Span span = tracer.buildSpan("one").start();
 executor.submit(new Runnable() {
     @Override
     public void run() {
-	try (Scope scope = tracer.scopeManager().activate(span)) {
+	try (Scope scope = tracer.activateSpan(span)) {
 	    throw new RuntimeException("Invalid state");
 	} catch (Exception exc) {
 	    Tags.ERROR.set(span, true);

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/late_span_finish/LateSpanFinishTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/late_span_finish/LateSpanFinishTest.java
@@ -72,9 +72,12 @@ public class LateSpanFinishTest {
             @Override
             public void run() {
                 /* Alternative to calling activate() is to pass it manually to asChildOf() for each created Span. */
-                try (Scope scope = tracer.scopeManager().activate(parentSpan, false)) {
-                    try (Scope childScope1 = tracer.buildSpan("task1").startActive(true)) {
+                try (Scope scope = tracer.scopeManager().activate(parentSpan)) {
+                    Span childSpan = tracer.buildSpan("task1").start();
+                    try (Scope childScope = tracer.scopeManager().activate(childSpan)) {
                         sleep(55);
+                    } finally {
+                        childSpan.finish();
                     }
                 }
             }
@@ -83,9 +86,12 @@ public class LateSpanFinishTest {
         executor.submit(new Runnable() {
             @Override
             public void run() {
-                try (Scope span = tracer.scopeManager().activate(parentSpan, false)) {
-                    try (Scope childScope2 = tracer.buildSpan("task2").startActive(true)) {
+                try (Scope scope = tracer.scopeManager().activate(parentSpan)) {
+                    Span childSpan = tracer.buildSpan("task2").start();
+                    try (Scope childScope = tracer.scopeManager().activate(childSpan)) {
                         sleep(85);
+                    } finally {
+                        childSpan.finish();
                     }
                 }
             }

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/late_span_finish/LateSpanFinishTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/late_span_finish/LateSpanFinishTest.java
@@ -40,7 +40,7 @@ public class LateSpanFinishTest {
     @Test
     public void test() throws Exception {
         // Create a Span manually and use it as parent of a pair of subtasks
-        Span parentSpan = tracer.buildSpan("parent").startManual();
+        Span parentSpan = tracer.buildSpan("parent").start();
         submitTasks(parentSpan);
 
         // Wait for the threadpool to be done first, instead of polling/waiting

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/late_span_finish/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/late_span_finish/README.md
@@ -7,17 +7,8 @@ This example shows a `Span` for a top-level operation, with independent, unknown
 executor.submit(new Runnable() {
     @Override
     public void run() {
-	try (Scope scope = tracer.scopeManager().activate(parentSpan, false)) {
-            ...
-	}
-    }
-});
-executor.submit(new Runnable() {
-    @Override
-    public void run() {
-	try (Scope span = tracer.scopeManager().activate(parentSpan, false)) {
-            ...
-	}
+        try (Scope scope = tracer.scopeManager().activate(parentSpan)) {
+        }
     }
 });
 ```

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/listener_per_request/Client.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/listener_per_request/Client.java
@@ -50,7 +50,7 @@ public class Client {
     public Future<Object> send(final Object message) {
         Span span = tracer.buildSpan("send").
                 withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
-                .startManual();
+                .start();
         return execute(message, new ResponseListener(span));
     }
 }

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/Client.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/Client.java
@@ -14,6 +14,7 @@
 package io.opentracing.testbed.multiple_callbacks;
 
 import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.util.AutoFinishScope;
 import io.opentracing.util.AutoFinishScope.Continuation;
@@ -48,7 +49,9 @@ public class Client {
                 logger.info("Child thread with message '{}' started", message);
 
                 try (Scope parentScope = cont.activate()) {
-                    try (Scope subtaskScope = tracer.buildSpan("subtask").startActive()) {
+
+                    Span span = tracer.buildSpan("subtask").start();
+                    try (Scope subtaskScope = tracer.activateSpan(span)) {
                         // Simulate work.
                         sleep(milliseconds);
                     }

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/Client.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/Client.java
@@ -48,7 +48,7 @@ public class Client {
                 logger.info("Child thread with message '{}' started", message);
 
                 try (Scope parentScope = cont.activate()) {
-                    try (Scope subtaskScope = tracer.buildSpan("subtask").startActive(false)) {
+                    try (Scope subtaskScope = tracer.buildSpan("subtask").startActive()) {
                         // Simulate work.
                         sleep(milliseconds);
                     }

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/MultipleCallbacksTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/MultipleCallbacksTest.java
@@ -14,6 +14,7 @@
 package io.opentracing.testbed.multiple_callbacks;
 
 import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.util.AutoFinishScopeManager;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
@@ -37,7 +38,8 @@ public class MultipleCallbacksTest {
     @Test
     public void test() throws Exception {
         Client client = new Client(tracer);
-        try (Scope scope = tracer.buildSpan("parent").startActive()) {
+        Span span = tracer.buildSpan("parent").start();
+        try (Scope scope = tracer.activateSpan(span)) {
             client.send("task1", 300);
             client.send("task2", 200);
             client.send("task3", 100);

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/MultipleCallbacksTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/MultipleCallbacksTest.java
@@ -37,7 +37,7 @@ public class MultipleCallbacksTest {
     @Test
     public void test() throws Exception {
         Client client = new Client(tracer);
-        try (Scope scope = tracer.buildSpan("parent").startActive(false)) {
+        try (Scope scope = tracer.buildSpan("parent").startActive()) {
             client.send("task1", 300);
             client.send("task2", 200);
             client.send("task3", 100);

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/README.md
@@ -13,7 +13,7 @@ return executor.submit(new Callable<Object>() {
     @Override
     public Object call() throws Exception {
 	try (Scope parentScope = cont.activate()) {
-	    try (Scope subtaskScope = tracer.buildSpan("subtask").startActive(false)) {
+	    try (Scope subtaskScope = tracer.buildSpan("subtask").startActive()) {
                 ...
 
 ```

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/multiple_callbacks/README.md
@@ -12,8 +12,12 @@ final Continuation cont = ((AutoFinishScope)scope).capture();
 return executor.submit(new Callable<Object>() {
     @Override
     public Object call() throws Exception {
+	logger.info("Child thread with message '{}' started", message);
+
 	try (Scope parentScope = cont.activate()) {
-	    try (Scope subtaskScope = tracer.buildSpan("subtask").startActive()) {
-                ...
+
+	    Span span = tracer.buildSpan("subtask").start();
+	    try (Scope subtaskScope = tracer.activateSpan(span)) {
+		...
 
 ```

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/nested_callbacks/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/nested_callbacks/README.md
@@ -3,13 +3,13 @@
 This example shows a `Span` for a top-level operation, and how it can be manually passed down on a list of nested callbacks (always one at a time), re-activated on each one, and finished **only** when the last one executes.
 
 ```java
-try (Scope scope = tracer.scopeManager().activate(span, false)) {
+try (Scope scope = tracer.scopeManager().activate(span)) {
     span.setTag("key1", "1");
 
     executor.submit(new Runnable() {
 	@Override
 	public void run() {
-	    try (Scope scope = tracer.scopeManager().activate(span, false)) {
+	    try (Scope scope = tracer.scopeManager().activate(span)) {
 		span.setTag("key2", "2");
                 ...
 

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/promise_propagation/Promise.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/promise_propagation/Promise.java
@@ -15,6 +15,7 @@ package io.opentracing.testbed.promise_propagation;
 
 import io.opentracing.References;
 import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.tag.Tags;
 import java.util.Collection;
@@ -24,7 +25,7 @@ import java.util.LinkedList;
 public class Promise<T> {
   private final PromiseContext context;
   private final MockTracer tracer;
-  private final Scope parentScope;
+  private final Span parentSpan;
 
   private final Collection<SuccessCallback<T>> successCallbacks = new LinkedList<>();
   private final Collection<ErrorCallback> errorCallbacks = new LinkedList<>();
@@ -34,7 +35,7 @@ public class Promise<T> {
 
     // Passed along here for testing. Normally should be referenced via GlobalTracer.get().
     this.tracer = tracer;
-    parentScope = tracer.scopeManager().active();
+    parentSpan = tracer.scopeManager().activeSpan();
   }
 
   public void onSuccess(SuccessCallback<T> successCallback) {
@@ -51,16 +52,15 @@ public class Promise<T> {
           new Runnable() {
             @Override
             public void run() {
-              Scope child = tracer
+              Span childSpan = tracer
                   .buildSpan("success")
-                  .addReference(References.FOLLOWS_FROM, parentScope.span().context())
+                  .addReference(References.FOLLOWS_FROM, parentSpan.context())
                   .withTag(Tags.COMPONENT.getKey(), "success")
-                  .startActive();
-              try {
+                  .start();
+              try (Scope childScope = tracer.activateSpan(childSpan)) {
                 callback.accept(result);
               } finally {
-                child.close();
-                child.span().finish();
+                childSpan.finish();
               }
               context.getPhaser().arriveAndAwaitAdvance(); // trace reported
             }
@@ -74,16 +74,15 @@ public class Promise<T> {
           new Runnable() {
             @Override
             public void run() {
-                Scope child = tracer
+                Span childSpan = tracer
                     .buildSpan("error")
-                    .addReference(References.FOLLOWS_FROM, parentScope.span().context())
+                    .addReference(References.FOLLOWS_FROM, parentSpan.context())
                     .withTag(Tags.COMPONENT.getKey(), "error")
-                    .startActive();
-                try {
+                    .start();
+                try (Scope childScope = tracer.activateSpan(childSpan)) {
                   callback.accept(error);
                 } finally {
-                    child.close();
-                    child.span().finish();
+                    childSpan.finish();
                 }
                 context.getPhaser().arriveAndAwaitAdvance(); // trace reported
             }

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/promise_propagation/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/promise_propagation/README.md
@@ -12,16 +12,15 @@ A top-level `Span` is created for the main work, and later passed to the `Promis
           new Runnable() {
             @Override
             public void run() {
-              Scope child = tracer
+              Span childSpan = tracer
                   .buildSpan("success")
-                  .addReference(References.FOLLOWS_FROM, parentScope.span().context())
+                  .addReference(References.FOLLOWS_FROM, parentSpan.context())
                   .withTag(Tags.COMPONENT.getKey(), "success")
-                  .startActive();
-              try {
+                  .start();
+              try (Scope childScope = tracer.activateSpan(childSpan)) {
                 callback.accept(result);
               } finally {
-                child.close();
-                child.span().finish();
+                childSpan.finish();
               }
               ...
             }

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/promise_propagation/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/promise_propagation/README.md
@@ -12,14 +12,18 @@ A top-level `Span` is created for the main work, and later passed to the `Promis
           new Runnable() {
             @Override
             public void run() {
-                try (Scope child =
-                    tracer
-                        .buildSpan("success")
-                            .addReference(References.FOLLOWS_FROM, parentScope.span().context())
-                        .startActive(true)) {
-                  callback.accept(result);
-                }
-                ...
+              Scope child = tracer
+                  .buildSpan("success")
+                  .addReference(References.FOLLOWS_FROM, parentScope.span().context())
+                  .withTag(Tags.COMPONENT.getKey(), "success")
+                  .startActive();
+              try {
+                callback.accept(result);
+              } finally {
+                child.close();
+                child.span().finish();
+              }
+              ...
             }
           });
     }

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/suspend_resume_propagation/README.md
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/suspend_resume_propagation/README.md
@@ -7,7 +7,7 @@ This example shows `Span` usage with the suspend-resume model found in asynchron
 ```java
   // SuspendResume
   public void doPart(String name) {
-    try (Scope scope = tracer.scopeManager().activate(span, false)) {
+    try (Scope scope = tracer.scopeManager().activate(span)) {
       scope.span().log("part: " + name);
     }
   }

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/suspend_resume_propagation/SuspendResume.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/suspend_resume_propagation/SuspendResume.java
@@ -31,18 +31,18 @@ public class SuspendResume {
     // Passed along here for testing. Normally should be referenced via GlobalTracer.get().
     this.tracer = tracer;
 
-    try (Scope scope =
-        tracer
-            .buildSpan("job " + id)
-            .withTag(Tags.COMPONENT.getKey(), "suspend-resume")
-            .startActive()) {
-      span = scope.span();
+    Span span = tracer
+        .buildSpan("job " + id)
+        .withTag(Tags.COMPONENT.getKey(), "suspend-resume")
+        .start();
+    try (Scope scope = tracer.scopeManager().activate(span)) {
+        this.span = span;
     }
   }
 
   public void doPart(String name) {
     try (Scope scope = tracer.scopeManager().activate(span)) {
-      scope.span().log("part: " + name);
+      span.log("part: " + name);
     }
   }
 

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/suspend_resume_propagation/SuspendResume.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/suspend_resume_propagation/SuspendResume.java
@@ -35,13 +35,13 @@ public class SuspendResume {
         tracer
             .buildSpan("job " + id)
             .withTag(Tags.COMPONENT.getKey(), "suspend-resume")
-            .startActive(false)) {
+            .startActive()) {
       span = scope.span();
     }
   }
 
   public void doPart(String name) {
-    try (Scope scope = tracer.scopeManager().activate(span, false)) {
+    try (Scope scope = tracer.scopeManager().activate(span)) {
       scope.span().log("part: " + name);
     }
   }

--- a/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
@@ -27,6 +27,11 @@ public class AutoFinishScopeManager implements ScopeManager {
     }
 
     @Override
+    public AutoFinishScope activate(Span span) {
+        return new AutoFinishScope(this, new AtomicInteger(1), span);
+    }
+
+    @Override
     public AutoFinishScope active() {
         return tlsScope.get();
     }

--- a/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
@@ -36,4 +36,9 @@ public class AutoFinishScopeManager implements ScopeManager {
         return tlsScope.get();
     }
 
+    @Override
+    public Span activeSpan() {
+        AutoFinishScope scope = tlsScope.get();
+        return scope == null ? null : scope.span();
+    }
 }

--- a/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
@@ -13,6 +13,7 @@
  */
 package io.opentracing.util;
 
+import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
@@ -176,6 +177,11 @@ public final class GlobalTracer implements Tracer {
     @Override
     public Span activeSpan() {
         return tracer.activeSpan();
+    }
+
+    @Override
+    public Scope activateSpan(Span span) {
+        return tracer.activateSpan(span);
     }
 
     @Override

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScope.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScope.java
@@ -29,6 +29,10 @@ public class ThreadLocalScope implements Scope {
     private final boolean finishOnClose;
     private final ThreadLocalScope toRestore;
 
+    ThreadLocalScope(ThreadLocalScopeManager scopeManager, Span wrapped) {
+        this(scopeManager, wrapped, false);
+    }
+
     ThreadLocalScope(ThreadLocalScopeManager scopeManager, Span wrapped, boolean finishOnClose) {
         this.scopeManager = scopeManager;
         this.wrapped = wrapped;

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
@@ -39,4 +39,10 @@ public class ThreadLocalScopeManager implements ScopeManager {
     public Scope active() {
         return tlsScope.get();
     }
+
+    @Override
+    public Span activeSpan() {
+        Scope scope = tlsScope.get();
+        return scope == null ? null : scope.span();
+    }
 }

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
@@ -31,6 +31,11 @@ public class ThreadLocalScopeManager implements ScopeManager {
     }
 
     @Override
+    public Scope activate(Span span) {
+        return new ThreadLocalScope(this, span);
+    }
+
+    @Override
     public Scope active() {
         return tlsScope.get();
     }

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeManagerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeManagerTest.java
@@ -42,8 +42,7 @@ public class ThreadLocalScopeManagerTest {
     public void defaultActivate() throws Exception {
         Span span = mock(Span.class);
 
-        // We can't use 1.7 features like try-with-resources in this repo without meddling with pom details for tests.
-        Scope scope = source.activate(span, false);
+        Scope scope = source.activate(span);
         try {
             assertNotNull(scope);
             Scope otherScope = source.active();

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeManagerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeManagerTest.java
@@ -39,6 +39,12 @@ public class ThreadLocalScopeManagerTest {
     }
 
     @Test
+    public void missingActiveSpan() throws Exception {
+        Span missingSpan = source.activeSpan();
+        assertNull(missingSpan);
+    }
+
+    @Test
     public void defaultActivate() throws Exception {
         Span span = mock(Span.class);
 
@@ -47,6 +53,9 @@ public class ThreadLocalScopeManagerTest {
             assertNotNull(scope);
             Scope otherScope = source.active();
             assertEquals(otherScope, scope);
+
+            Span otherSpan = source.activeSpan();
+            assertEquals(otherSpan, span);
         } finally {
             scope.close();
         }
@@ -54,9 +63,12 @@ public class ThreadLocalScopeManagerTest {
         // Make sure the Span is not finished.
         verify(span, times(0)).finish();
 
-        // And now it's gone:
+        // And now Scope/Span are gone:
         Scope missingScope = source.active();
         assertNull(missingScope);
+
+        Span missingSpan = source.activeSpan();
+        assertNull(missingSpan);
     }
 
     @Test
@@ -68,6 +80,7 @@ public class ThreadLocalScopeManagerTest {
         try {
             assertNotNull(scope);
             assertNotNull(source.active());
+            assertNotNull(source.activeSpan());
         } finally {
             scope.close();
         }
@@ -75,8 +88,9 @@ public class ThreadLocalScopeManagerTest {
         // Make sure the Span got finish()ed.
         verify(span, times(1)).finish();
 
-        // Verify it's gone.
+        // Verify Scope/Span are gone.
         assertNull(source.active());
+        assertNull(source.activeSpan());
     }
 
     @Test
@@ -88,6 +102,7 @@ public class ThreadLocalScopeManagerTest {
         try {
             assertNotNull(scope);
             assertNotNull(source.active());
+            assertNotNull(source.activeSpan());
         } finally {
             scope.close();
         }
@@ -95,7 +110,8 @@ public class ThreadLocalScopeManagerTest {
         // Make sure the Span did *not* get finish()ed.
         verify(span, never()).finish();
 
-        // Verify it's gone.
+        // Verify Scope/Span are gone.
         assertNull(source.active());
+        assertNull(source.activeSpan());
     }
 }

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeTest.java
@@ -38,13 +38,12 @@ public class ThreadLocalScopeTest {
         Span backgroundSpan = mock(Span.class);
         Span foregroundSpan = mock(Span.class);
 
-        // Quasi try-with-resources (this is 1.6).
-        Scope backgroundActive = scopeManager.activate(backgroundSpan, true);
+        Scope backgroundActive = scopeManager.activate(backgroundSpan);
         try {
             assertNotNull(backgroundActive);
 
             // Activate a new Scope on top of the background one.
-            Scope foregroundActive = scopeManager.activate(foregroundSpan, true);
+            Scope foregroundActive = scopeManager.activate(foregroundSpan);
             try {
                 Scope shouldBeForeground = scopeManager.active();
                 assertEquals(foregroundActive, shouldBeForeground);
@@ -60,8 +59,8 @@ public class ThreadLocalScopeTest {
         }
 
         // The background and foreground Spans should be finished.
-        verify(backgroundSpan, times(1)).finish();
-        verify(foregroundSpan, times(1)).finish();
+        verify(backgroundSpan, times(0)).finish();
+        verify(foregroundSpan, times(0)).finish();
 
         // And now nothing is active.
         Scope missingSpan = scopeManager.active();
@@ -72,8 +71,8 @@ public class ThreadLocalScopeTest {
     public void testDeactivateWhenDifferentSpanIsActive() {
         Span span = mock(Span.class);
 
-        Scope active = scopeManager.activate(span, false);
-        scopeManager.activate(mock(Span.class), false);
+        Scope active = scopeManager.activate(span);
+        scopeManager.activate(mock(Span.class));
         active.close();
 
         verify(span, times(0)).finish();


### PR DESCRIPTION
Addresses #291 

`SpanBuilder.startActive(Span, boolean)` and `ScopeManager.activate(Span, bool)` have been kept, but as deprecated methods.

Updated the `opentracing-testbed` code to use this change, and added a new, small, `error-reporting` case.

cc @felixbarny @adriancole @yurishkuro @tedsuo @sjoerdtalsma 