### PR TITLE
Allow injecting into maps of type Map<String,Object>

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInjectAdapter.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInjectAdapter.java
@@ -28,9 +28,9 @@ import java.util.Map;
  * @see Tracer#inject(SpanContext, Format, Object)
  */
 public final class TextMapInjectAdapter implements TextMap {
-    private final Map<String,String> map;
+    private final Map<String, ? super String> map;
 
-    public TextMapInjectAdapter(final Map<String,String> map) {
+    public TextMapInjectAdapter(final Map<String, ? super String> map) {
         this.map = map;
     }
 

--- a/opentracing-api/src/test/java/io/opentracing/propagation/TextMapInjectAdapterTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/propagation/TextMapInjectAdapterTest.java
@@ -26,7 +26,7 @@ public class TextMapInjectAdapterTest {
 
     @Test
     public void testPut() {
-        Map<String, String> headers = new LinkedHashMap<String, String>();
+        Map<String, Object> headers = new LinkedHashMap<String, Object>();
         TextMapInjectAdapter injectAdapter = new TextMapInjectAdapter(headers);
         injectAdapter.put("foo", "bar");
 


### PR DESCRIPTION
For the inject case, it doesn’t matter so much that the generic type is declared as String.