### PR TITLE
Add generic typed setTag/withTag

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/Span.java
@@ -13,6 +13,7 @@
  */
 package io.opentracing;
 
+import io.opentracing.tag.AbstractTag;
 import java.util.Map;
 
 /**
@@ -43,6 +44,9 @@ public interface Span {
 
     /** Same as {@link #setTag(String, String)}, but for numeric values. */
     Span setTag(String key, Number value);
+
+    /** Same as {@link #setTag(String, String)}, but with typed value. */
+    <T> Span setTag(AbstractTag<T> key, T value);
 
     /**
      * Log key:value pairs to the Span with the current walltime timestamp.

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -14,6 +14,7 @@
 package io.opentracing;
 
 import io.opentracing.propagation.Format;
+import io.opentracing.tag.AbstractTag;
 
 /**
  * Tracer is a simple, thin interface for Span creation and propagation across arbitrary transports.
@@ -161,6 +162,9 @@ public interface Tracer {
 
         /** Same as {@link Span#setTag(String, Number)}, but for the span being built. */
         SpanBuilder withTag(String key, Number value);
+
+        /** Same as {@link AbstractTag#set(Span, T)}, but for the span being built. */
+        <T> SpanBuilder withTag(AbstractTag<T> tag, T value);
 
         /** Specify a timestamp of when the Span was started, represented in microseconds since epoch. */
         SpanBuilder withStartTimestamp(long microseconds);

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
@@ -14,6 +14,9 @@
 package io.opentracing.mock;
 
 import io.opentracing.References;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.tag.AbstractTag;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -21,9 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
-
-import io.opentracing.Span;
-import io.opentracing.SpanContext;
 
 /**
  * MockSpans are created via MockTracer.buildSpan(...), but they are also returned via calls to
@@ -134,6 +134,11 @@ public final class MockSpan implements Span {
     @Override
     public MockSpan setTag(String key, Number value) {
         return setObjectTag(key, value);
+    }
+
+    @Override
+    public <T> Span setTag(AbstractTag<T> key, T value) {
+        return setObjectTag(key.getKey(), value);
     }
 
     private synchronized MockSpan setObjectTag(String key, Object value) {

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -13,6 +13,7 @@
  */
 package io.opentracing.mock;
 
+import io.opentracing.tag.AbstractTag;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -255,6 +256,12 @@ public class MockTracer implements Tracer {
         @Override
         public SpanBuilder withTag(String key, Number value) {
             this.initialTags.put(key, value);
+            return this;
+        }
+
+        @Override
+        public <T> Tracer.SpanBuilder withTag(AbstractTag<T> tag, T value) {
+            this.initialTags.put(tag.getKey(), value);
             return this;
         }
 

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
@@ -15,6 +15,7 @@ package io.opentracing.noop;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
+import io.opentracing.tag.AbstractTag;
 
 import java.util.Map;
 
@@ -41,6 +42,11 @@ final class NoopSpanImpl implements NoopSpan {
 
     @Override
     public NoopSpan setTag(String key, Number value) { return this; }
+
+    @Override
+    public <T> Span setTag(AbstractTag<T> key, T value) {
+        return this;
+    }
 
     @Override
     public NoopSpan log(Map<String, ?> fields) { return this; }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
@@ -17,9 +17,7 @@ import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-
-import java.util.Collections;
-import java.util.Map;
+import io.opentracing.tag.AbstractTag;
 
 public interface NoopSpanBuilder extends Tracer.SpanBuilder {
     NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
@@ -57,6 +55,11 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
 
     @Override
     public Tracer.SpanBuilder withTag(String key, Number value) {
+        return this;
+    }
+
+    @Override
+    public <T> Tracer.SpanBuilder withTag(AbstractTag<T> key, T value) {
         return this;
     }
 


### PR DESCRIPTION
Reduces the need to call Tags.SOMETAG.getKey() and adds type safety for setTag if done from the span.

Fixes #271