### PR TITLE
Allow clearing the current Scope.

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/ScopeManager.java
+++ b/opentracing-api/src/main/java/io/opentracing/ScopeManager.java
@@ -92,6 +92,16 @@ public interface ScopeManager {
     Span activeSpan();
 
     /**
+     * Clear the current active state, setting both {@link #active()} and
+     * {@link #activeSpan()} to null for the current context (usually a thread).
+     *
+     * <p>
+     * This method can be called to discard any previously leaked {@link Scope} objects
+     * that were unintentionally left active.
+     */
+    void clear();
+
+    /**
      * @deprecated use {@link #activate(Span)} instead.
      * Set the specified {@link Span} as the active instance for the current
      * context (usually a thread).

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
@@ -49,6 +49,10 @@ class NoopScopeManagerImpl implements NoopScopeManager {
         return NoopSpan.INSTANCE;
     }
 
+    @Override
+    public void clear() {
+    }
+
     static class NoopScopeImpl implements NoopScopeManager.NoopScope {
         @Override
         public void close() {}

--- a/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
@@ -41,4 +41,9 @@ public class AutoFinishScopeManager implements ScopeManager {
         AutoFinishScope scope = tlsScope.get();
         return scope == null ? null : scope.span();
     }
+
+    @Override
+    public void clear() {
+        tlsScope.set(null);
+    }
 }

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
@@ -45,4 +45,9 @@ public class ThreadLocalScopeManager implements ScopeManager {
         Scope scope = tlsScope.get();
         return scope == null ? null : scope.span();
     }
+
+    @Override
+    public void clear() {
+        tlsScope.set(null);
+    }
 }

--- a/opentracing-util/src/test/java/io/opentracing/util/AutoFinishScopeManagerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/AutoFinishScopeManagerTest.java
@@ -57,4 +57,18 @@ public class AutoFinishScopeManagerTest {
         Scope missingSpan = source.active();
         assertNull(missingSpan);
     }
+
+    @Test
+    public void clear() throws Exception {
+        Span span = mock(Span.class);
+
+        Scope scope = source.activate(span);
+        assertNotNull(scope);
+        assertNotNull(source.active());
+        assertNotNull(source.activeSpan());
+
+        source.clear();
+        assertNull(source.active());
+        assertNull(source.activeSpan());
+    }
 }

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeManagerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeManagerTest.java
@@ -114,4 +114,18 @@ public class ThreadLocalScopeManagerTest {
         assertNull(source.active());
         assertNull(source.activeSpan());
     }
+
+    @Test
+    public void clear() throws Exception {
+        Span span = mock(Span.class);
+
+        Scope scope = source.activate(span);
+        assertNotNull(scope);
+        assertNotNull(source.active());
+        assertNotNull(source.activeSpan());
+
+        source.clear();
+        assertNull(source.active());
+        assertNull(source.activeSpan());
+    }
 }


### PR DESCRIPTION
Decided to take on being able to clear the current `Scope`, if any - this is done to prevent leaking `Scope` objects that were left around unintentionally.

If merged, this could become part of the next iteration of https://github.com/opentracing/specification/pull/122 ;)

@yurishkuro @adriancole @felixbarny @tylerbenson 