### PR TITLE
Split Inject and Extract Builtin interfaces

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/propagation/BinaryAdapters.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/BinaryAdapters.java
@@ -27,7 +27,7 @@ public final class BinaryAdapters {
      *
      * @return The new {@link Binary} carrier used for extraction.
      */
-    public static Binary extractionCarrier(ByteBuffer buffer) {
+    public static BinaryExtract extractionCarrier(ByteBuffer buffer) {
         if (buffer == null) {
             throw new NullPointerException();
         }
@@ -38,7 +38,7 @@ public final class BinaryAdapters {
     /**
      * Creates an outbound {@link Binary} instance used for injection with the
      * specified ByteBuffer as output. ByteBuffer.limit() will be set to the value
-     * of the requested length at {@link Binary#injectionBuffer()} time, and
+     * of the requested length at {@link BinaryInject#injectionBuffer} time, and
      * AssertionError will be thrown if the requested length is larger than
      * the remaining length of ByteBuffer.
      *
@@ -46,20 +46,15 @@ public final class BinaryAdapters {
      *
      * @return The new Binary carrier used for injection.
      */
-    public static Binary injectionCarrier(ByteBuffer buffer) {
+    public static BinaryInject injectionCarrier(ByteBuffer buffer) {
         return new BinaryInjectAdapter(buffer);
     }
 
-    static class BinaryExtractAdapter implements Binary {
+    static class BinaryExtractAdapter implements BinaryExtract {
         ByteBuffer buffer;
 
         public BinaryExtractAdapter(ByteBuffer buffer) {
             this.buffer = buffer;
-        }
-
-        @Override
-        public ByteBuffer injectionBuffer(int length) {
-            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -68,7 +63,7 @@ public final class BinaryAdapters {
         }
     }
 
-    static class BinaryInjectAdapter implements Binary {
+    static class BinaryInjectAdapter implements BinaryInject {
         ByteBuffer buffer;
 
         public BinaryInjectAdapter(ByteBuffer buffer) {
@@ -86,11 +81,6 @@ public final class BinaryAdapters {
 
             buffer.limit(buffer.position() + length);
             return buffer;
-        }
-
-        @Override
-        public ByteBuffer extractionBuffer() {
-            throw new UnsupportedOperationException();
         }
     }
 }

--- a/opentracing-api/src/main/java/io/opentracing/propagation/BinaryExtract.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/BinaryExtract.java
@@ -14,23 +14,28 @@
 package io.opentracing.propagation;
 
 import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import java.nio.ByteBuffer;
 
 /**
- * Binary is an interface defining the required operations for a binary carrier for
- * Tracer.inject() and Tracer.extract(). Binary can be defined either as inbound (extraction)
- * or outbound (injection).
+ * {@link BinaryExtract} is an interface defining the required operations for a binary carrier for
+ * {@link Tracer#extract} only. {@link BinaryExtract} is defined as inbound (extraction).
  *
- * When Binary is defined as inbound, extractionBuffer() will be called to retrieve the ByteBuffer
- * containing the data used for SpanContext extraction.
- *
- * When Binary is defined as outbound, setInjectBufferLength() will be called in order to hint
- * the required buffer length to inject the SpanContext, and injectionBuffer() will be called
- * afterwards to retrieve the actual ByteBuffer used for the SpanContext injection.
+ * When called with {@link Tracer#extract}, {@link #extractionBuffer} will be called to retrieve the {@link ByteBuffer}
+ * containing the data used for {@link SpanContext} extraction.
  *
  * @see Format.Builtin#BINARY
- * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
  * @see io.opentracing.Tracer#extract(Format, Object)
  */
-public interface Binary extends BinaryInject, BinaryExtract {
+public interface BinaryExtract {
+
+    /**
+     * Gets the buffer containing the data used for {@link SpanContext} extraction.
+     *
+     * It is an error to call this method when Binary is used
+     * for {@link SpanContext} injection.
+     *
+     * @return The buffer used for {@link SpanContext} extraction.
+     */
+    ByteBuffer extractionBuffer();
 }

--- a/opentracing-api/src/main/java/io/opentracing/propagation/BinaryInject.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/BinaryInject.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.propagation;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import java.nio.ByteBuffer;
+
+/**
+ * {@link BinaryInject} is an interface defining the required operations for a binary carrier for
+ * {@link Tracer#inject} only. {@link BinaryInject} is defined as outbound (injection).
+ *
+ * When called with {@link Tracer#inject}, {@link #injectionBuffer} will be called
+ * to retrieve the actual {@link ByteBuffer} used for the {@link SpanContext} injection.
+ *
+ * @see Format.Builtin#BINARY
+ * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
+ */
+public interface BinaryInject {
+    /**
+     * Gets the buffer used to store data as part of {@link SpanContext} injection.
+     *
+     * The lenght parameter hints the buffer length required for
+     * {@link SpanContext} injection. The user may use this to allocate a new
+     * ByteBuffer or resize an existing one.
+     *
+     * It is an error to call this method when Binary is used
+     * for {@link SpanContext} extraction.
+     *
+     * @param length The buffer length required for {@link SpanContext} injection.
+     *               It needs to be larger than zero.
+     *
+     * @return The buffer used for {@link SpanContext} injection.
+     */
+    ByteBuffer injectionBuffer(int length);
+}

--- a/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/Format.java
@@ -53,6 +53,22 @@ public interface Format<C> {
         public final static Format<TextMap> TEXT_MAP = new Builtin<TextMap>("TEXT_MAP");
 
         /**
+         * Like {@link Builtin#TEXT_MAP} but specific for calling {@link Tracer#inject} with.
+         *
+         * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
+         * @see Format
+         */
+        public final static Format<TextMapInject> TEXT_MAP_INJECT = new Builtin<TextMapInject>("TEXT_MAP_INJECT");
+
+        /**
+         * Like {@link Builtin#TEXT_MAP} but specific for calling {@link Tracer#extract} with.
+         *
+         * @see io.opentracing.Tracer#extract(Format, Object)
+         * @see Format
+         */
+        public final static Format<TextMapExtract> TEXT_MAP_EXTRACT = new Builtin<TextMapExtract>("TEXT_MAP_EXTRACT");
+
+        /**
          * The HTTP_HEADERS format allows for HTTP-header-compatible String-&gt;String map encoding of SpanContext state
          * for Tracer.inject and Tracer.extract.
          *
@@ -75,6 +91,22 @@ public interface Format<C> {
          * @see Format
          */
         public final static Format<Binary> BINARY = new Builtin<Binary>("BINARY");
+
+        /**
+         * Like {@link Builtin#BINARY} but specific for calling {@link Tracer#inject} with.
+         *
+         * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
+         * @see Format
+         */
+        public final static Format<BinaryInject> BINARY_INJECT = new Builtin<BinaryInject>("BINARY_INJECT");
+
+        /**
+         * Like {@link Builtin#BINARY} but specific for calling {@link Tracer#extract} with.
+         *
+         * @see io.opentracing.Tracer#extract(Format, Object)
+         * @see Format
+         */
+        public final static Format<BinaryExtract> BINARY_EXTRACT = new Builtin<BinaryExtract>("BINARY_EXTRACT");
 
         /**
          * @return Short name for built-in formats as they tend to show up in exception messages.

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMap.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMap.java
@@ -25,28 +25,5 @@ import java.util.Map;
  * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
  * @see io.opentracing.Tracer#extract(Format, Object)
  */
-public interface TextMap extends Iterable<Map.Entry<String, String>> {
-    /**
-     * Gets an iterator over arbitrary key:value pairs from the TextMapReader.
-     *
-     * @return entries in the TextMap backing store; note that for some Formats, the iterator may include entries that
-     * were never injected by a Tracer implementation (e.g., unrelated HTTP headers)
-     *
-     * @see io.opentracing.Tracer#extract(Format, Object)
-     * @see Format.Builtin#TEXT_MAP
-     * @see Format.Builtin#HTTP_HEADERS
-     */
-    Iterator<Map.Entry<String,String>> iterator();
-
-    /**
-     * Puts a key:value pair into the TextMapWriter's backing store.
-     *
-     * @param key a String, possibly with constraints dictated by the particular Format this TextMap is paired with
-     * @param value a String, possibly with constraints dictated by the particular Format this TextMap is paired with
-     *
-     * @see io.opentracing.Tracer#inject(io.opentracing.SpanContext, Format, Object)
-     * @see Format.Builtin#TEXT_MAP
-     * @see Format.Builtin#HTTP_HEADERS
-     */
-    void put(String key, String value);
+public interface TextMap extends TextMapInject, TextMapExtract {
 }

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapAdapter.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapAdapter.java
@@ -13,28 +13,23 @@
  */
 package io.opentracing.propagation;
 
+import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import java.util.Iterator;
-
 import java.util.Map;
 
 /**
- * A TextMap carrier for use with Tracer.extract() ONLY (it has no mutating methods).
+ * A {@link TextMap} carrier for use with {@link Tracer#inject} and {@link Tracer#extract}.
  *
- * Note that the TextMap interface can be made to wrap around arbitrary data types (not just Map&lt;String, String&gt;
- * as illustrated here).
- *
+ * @see Tracer#inject(SpanContext, Format, Object)
  * @see Tracer#extract(Format, Object)
  */
-public class TextMapExtractAdapter implements TextMapExtract {
-    protected final Map<String,String> map;
-
-    public TextMapExtractAdapter(final Map<String,String> map) {
-        this.map = map;
+public class TextMapAdapter extends TextMapExtractAdapter implements TextMap {
+    public TextMapAdapter(Map<String, String> map) {
+        super(map);
     }
 
     @Override
-    public Iterator<Map.Entry<String, String>> iterator() {
-        return map.entrySet().iterator();
+    public void put(String key, String value) {
+        map.put(key, value);
     }
 }

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapExtract.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapExtract.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.propagation;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * {@link TextMapExtract} is a built-in carrier for {@link Tracer#extract} only.
+ * {@link TextMapExtract} implementations allows Tracers to write key:value String
+ * pairs to arbitrary underlying sources of data.
+ *
+ * @see io.opentracing.Tracer#extract(Format, Object)
+ */
+public interface TextMapExtract extends Iterable<Map.Entry<String, String>> {
+    /**
+     * Gets an iterator over arbitrary key:value pairs from the TextMapReader.
+     *
+     * @return entries in the TextMap backing store; note that for some Formats, the iterator may include entries that
+     * were never injected by a Tracer implementation (e.g., unrelated HTTP headers)
+     *
+     * @see io.opentracing.Tracer#extract(Format, Object)
+     * @see Format.Builtin#TEXT_MAP
+     * @see Format.Builtin#HTTP_HEADERS
+     */
+    Iterator<Map.Entry<String,String>> iterator();
+}

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInject.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInject.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.propagation;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+
+/**
+ * {@link TextMapInject} is a built-in carrier for {@link Tracer#inject} only.
+ * {@link TextMapInject} implementations allows Tracers to read key:value String
+ * pairs from arbitrary underlying sources of data.
+ *
+ * @see io.opentracing.Tracer#inject(SpanContext, Format, Object)
+ */
+public interface TextMapInject {
+
+    /**
+     * Puts a key:value pair into the TextMapWriter's backing store.
+     *
+     * @param key a String, possibly with constraints dictated by the particular Format this TextMap is paired with
+     * @param value a String, possibly with constraints dictated by the particular Format this TextMap is paired with
+     *
+     * @see io.opentracing.Tracer#inject(io.opentracing.SpanContext, Format, Object)
+     * @see Format.Builtin#TEXT_MAP
+     * @see Format.Builtin#HTTP_HEADERS
+     */
+    void put(String key, String value);
+}

--- a/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInjectAdapter.java
+++ b/opentracing-api/src/main/java/io/opentracing/propagation/TextMapInjectAdapter.java
@@ -27,16 +27,11 @@ import java.util.Map;
  *
  * @see Tracer#inject(SpanContext, Format, Object)
  */
-public final class TextMapInjectAdapter implements TextMap {
-    private final Map<String, ? super String> map;
+public class TextMapInjectAdapter implements TextMapInject {
+    protected final Map<String, ? super String> map;
 
     public TextMapInjectAdapter(final Map<String, ? super String> map) {
         this.map = map;
-    }
-
-    @Override
-    public Iterator<Map.Entry<String, String>> iterator() {
-        throw new UnsupportedOperationException("TextMapInjectAdapter should only be used with Tracer.inject()");
     }
 
     @Override

--- a/opentracing-api/src/test/java/io/opentracing/propagation/BinaryAdaptersTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/propagation/BinaryAdaptersTest.java
@@ -25,7 +25,7 @@ public class BinaryAdaptersTest {
     @Test
     public void testExtractBinary() {
         ByteBuffer buff = ByteBuffer.wrap(new byte[0]);
-        Binary binary = BinaryAdapters.extractionCarrier(buff);
+        BinaryExtract binary = BinaryAdapters.extractionCarrier(buff);
         assertEquals(buff, binary.extractionBuffer());
     }
 
@@ -34,35 +34,23 @@ public class BinaryAdaptersTest {
         BinaryAdapters.extractionCarrier(null);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testExtractBinaryInjectBuffer() {
-        Binary binary = BinaryAdapters.extractionCarrier(ByteBuffer.allocate(1));
-        binary.injectionBuffer(1);
-    }
-
     @Test
     public void testInjectBinary() {
         ByteBuffer buffer = ByteBuffer.allocate(1);
-        Binary binary = BinaryAdapters.injectionCarrier(buffer);
+        BinaryInject binary = BinaryAdapters.injectionCarrier(buffer);
         assertEquals(buffer, binary.injectionBuffer(1));
         assertEquals(0, buffer.position());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testInjectBinaryInvalidLength() {
-        Binary binary = BinaryAdapters.injectionCarrier(ByteBuffer.allocate(1));
+        BinaryInject binary = BinaryAdapters.injectionCarrier(ByteBuffer.allocate(1));
         binary.injectionBuffer(0);
     }
 
     @Test(expected = AssertionError.class)
     public void testInjectBinaryLargerLength() {
-        Binary binary = BinaryAdapters.injectionCarrier(ByteBuffer.allocate(1));
+        BinaryInject binary = BinaryAdapters.injectionCarrier(ByteBuffer.allocate(1));
         binary.injectionBuffer(2);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testInjectBinaryExtractBuffer() {
-        Binary binary = BinaryAdapters.injectionCarrier(ByteBuffer.allocate(1));
-        binary.extractionBuffer();
     }
 }

--- a/opentracing-api/src/test/java/io/opentracing/propagation/BuiltinFormatTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/propagation/BuiltinFormatTest.java
@@ -27,11 +27,15 @@ public class BuiltinFormatTest {
     @Test
     public void test_TEXT_MAP_toString() {
         assertEquals("Builtin.TEXT_MAP", Format.Builtin.TEXT_MAP.toString());
+        assertEquals("Builtin.TEXT_MAP_INJECT", Format.Builtin.TEXT_MAP_INJECT.toString());
+        assertEquals("Builtin.TEXT_MAP_EXTRACT", Format.Builtin.TEXT_MAP_EXTRACT.toString());
     }
 
     @Test
     public void test_BINARY_toString() {
         assertEquals("Builtin.BINARY", Format.Builtin.BINARY.toString());
+        assertEquals("Builtin.BINARY_INJECT", Format.Builtin.BINARY_INJECT.toString());
+        assertEquals("Builtin.BINARY_EXTRACT", Format.Builtin.BINARY_EXTRACT.toString());
     }
 
 }

--- a/opentracing-api/src/test/java/io/opentracing/propagation/TextMapExtractAdapterTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/propagation/TextMapExtractAdapterTest.java
@@ -28,13 +28,6 @@ import org.junit.Test;
  */
 public class TextMapExtractAdapterTest {
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testPut() {
-        Map<String, String> headers = new LinkedHashMap<String, String>();
-        TextMapExtractAdapter injectAdapter = new TextMapExtractAdapter(headers);
-        injectAdapter.put("foo", "bar");
-    }
-
     @Test
     public void testIterator() {
         Map<String, String> headers = new LinkedHashMap<String, String>();

--- a/opentracing-api/src/test/java/io/opentracing/propagation/TextMapInjectAdapterTest.java
+++ b/opentracing-api/src/test/java/io/opentracing/propagation/TextMapInjectAdapterTest.java
@@ -32,11 +32,4 @@ public class TextMapInjectAdapterTest {
 
         assertEquals("bar", headers.get("foo"));
     }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testIterator() {
-        Map<String, String> headers = new LinkedHashMap<String, String>();
-        TextMapInjectAdapter injectAdapter = new TextMapInjectAdapter(headers);
-        injectAdapter.iterator();
-    }
 }

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -13,6 +13,10 @@
  */
 package io.opentracing.mock;
 
+import io.opentracing.propagation.BinaryExtract;
+import io.opentracing.propagation.BinaryInject;
+import io.opentracing.propagation.TextMapExtract;
+import io.opentracing.propagation.TextMapInject;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -125,11 +129,11 @@ public class MockTracer implements Tracer {
 
             @Override
             public <C> void inject(MockSpan.MockContext ctx, Format<C> format, C carrier) {
-                if (!(carrier instanceof Binary)) {
-                    throw new IllegalArgumentException("Expected Binary, received " + carrier.getClass());
+                if (!(carrier instanceof BinaryInject)) {
+                    throw new IllegalArgumentException("Expected BinaryInject, received " + carrier.getClass());
                 }
 
-                Binary binary = (Binary) carrier;
+                BinaryInject binary = (BinaryInject) carrier;
                 ByteArrayOutputStream stream = new ByteArrayOutputStream();
                 ObjectOutputStream objStream = null;
                 try {
@@ -157,15 +161,15 @@ public class MockTracer implements Tracer {
 
             @Override
             public <C> MockSpan.MockContext extract(Format<C> format, C carrier) {
-                if (!(carrier instanceof Binary)) {
-                    throw new IllegalArgumentException("Expected Binary, received " + carrier.getClass());
+                if (!(carrier instanceof BinaryExtract)) {
+                    throw new IllegalArgumentException("Expected BinaryExtract, received " + carrier.getClass());
                 }
 
                 Long traceId = null;
                 Long spanId = null;
                 Map<String, String> baggage = new HashMap<>();
 
-                Binary binary = (Binary) carrier;
+                BinaryExtract binary = (BinaryExtract) carrier;
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                 ObjectInputStream objStream = null;
                 try {
@@ -203,8 +207,8 @@ public class MockTracer implements Tracer {
 
             @Override
             public <C> void inject(MockSpan.MockContext ctx, Format<C> format, C carrier) {
-                if (carrier instanceof TextMap) {
-                    TextMap textMap = (TextMap) carrier;
+                if (carrier instanceof TextMapInject) {
+                    TextMapInject textMap = (TextMapInject) carrier;
                     for (Map.Entry<String, String> entry : ctx.baggageItems()) {
                         textMap.put(BAGGAGE_KEY_PREFIX + entry.getKey(), entry.getValue());
                     }
@@ -221,8 +225,8 @@ public class MockTracer implements Tracer {
                 Long spanId = null;
                 Map<String, String> baggage = new HashMap<>();
 
-                if (carrier instanceof TextMap) {
-                    TextMap textMap = (TextMap) carrier;
+                if (carrier instanceof TextMapExtract) {
+                    TextMapExtract textMap = (TextMapExtract) carrier;
                     for (Map.Entry<String, String> entry : textMap) {
                         if (TRACE_ID_KEY.equals(entry.getKey())) {
                             traceId = Long.valueOf(entry.getValue());

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Client.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Client.java
@@ -40,7 +40,7 @@ public class Client {
             .withTag(Tags.COMPONENT.getKey(), "example-client")
             .start();
         try (Scope scope = tracer.activateSpan(span)) {
-            tracer.inject(span.context(), Builtin.TEXT_MAP, new TextMapInjectAdapter(message));
+            tracer.inject(span.context(), Builtin.TEXT_MAP_INJECT, new TextMapInjectAdapter(message));
             queue.put(message);
         } finally {
             span.finish();

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Server.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/client_server/Server.java
@@ -34,7 +34,7 @@ public class Server extends Thread {
     }
 
     private void process(Message message) {
-        SpanContext context = tracer.extract(Builtin.TEXT_MAP, new TextMapExtractAdapter(message));
+        SpanContext context = tracer.extract(Builtin.TEXT_MAP_EXTRACT, new TextMapExtractAdapter(message));
         Span span = tracer.buildSpan("receive")
           .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
           .withTag(Tags.COMPONENT.getKey(), "example-server")

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/error_reporting/ErrorReportingTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/error_reporting/ErrorReportingTest.java
@@ -63,7 +63,7 @@ public class ErrorReportingTest {
     /* Error handling in a callback capturing/activating the Span */
     @Test
     public void testCallbackError() {
-        Span span = tracer.buildSpan("one").start();
+        final Span span = tracer.buildSpan("one").start();
         executor.submit(new Runnable() {
             @Override
             public void run() {
@@ -98,7 +98,7 @@ public class ErrorReportingTest {
             while (res == null && retries++ < maxRetries) {
                 try {
                     throw new RuntimeException("No url could be fetched");
-                } catch (Exception exc) {
+                } catch (final Exception exc) {
                     span.log(new TreeMap<String, Object>() {{
                         put(Fields.EVENT, Tags.ERROR);
                         put(Fields.ERROR_OBJECT, exc);


### PR DESCRIPTION
If we had separate formats for inject and extract this refactor would have been much cleaner.

This allows us to better avoid partially implementing the TextMap interface and throwing an exception for the other method.

Since Binary is a new addition, I applied a similar refactoring to that.

Closes #315.