### PR TITLE
Do not use AbstractTag<T> for Span.setTag(), but the actual impls.

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/Span.java
@@ -13,9 +13,7 @@
  */
 package io.opentracing;
 
-import io.opentracing.tag.BooleanTag;
-import io.opentracing.tag.IntTag;
-import io.opentracing.tag.StringTag;
+import io.opentracing.tag.Tag;
 import java.util.Map;
 
 /**
@@ -47,14 +45,8 @@ public interface Span {
     /** Same as {@link #setTag(String, String)}, but for numeric values. */
     Span setTag(String key, Number value);
 
-    /** Same as {@link #setTag(String, String)}, but using BooleanTag.*/
-    Span setTag(BooleanTag tag, Boolean value);
-
-    /** Same as {@link #setTag(String, String)}, but using IntTag. */
-    Span setTag(IntTag tag, Integer value);
-
-    /** Same as {@link #setTag(String, String)}, but using StringTag. */
-    Span setTag(StringTag tag, String value);
+    /** Same as {@link #setTag(String, String)}, but with using Tag<T>. */
+    <T> Span setTag(Tag<T> tag, T value);
 
     /**
      * Log key:value pairs to the Span with the current walltime timestamp.

--- a/opentracing-api/src/main/java/io/opentracing/Span.java
+++ b/opentracing-api/src/main/java/io/opentracing/Span.java
@@ -13,7 +13,9 @@
  */
 package io.opentracing;
 
-import io.opentracing.tag.AbstractTag;
+import io.opentracing.tag.BooleanTag;
+import io.opentracing.tag.IntTag;
+import io.opentracing.tag.StringTag;
 import java.util.Map;
 
 /**
@@ -45,8 +47,14 @@ public interface Span {
     /** Same as {@link #setTag(String, String)}, but for numeric values. */
     Span setTag(String key, Number value);
 
-    /** Same as {@link #setTag(String, String)}, but with typed value. */
-    <T> Span setTag(AbstractTag<T> key, T value);
+    /** Same as {@link #setTag(String, String)}, but using BooleanTag.*/
+    Span setTag(BooleanTag tag, Boolean value);
+
+    /** Same as {@link #setTag(String, String)}, but using IntTag. */
+    Span setTag(IntTag tag, Integer value);
+
+    /** Same as {@link #setTag(String, String)}, but using StringTag. */
+    Span setTag(StringTag tag, String value);
 
     /**
      * Log key:value pairs to the Span with the current walltime timestamp.

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -14,7 +14,7 @@
 package io.opentracing;
 
 import io.opentracing.propagation.Format;
-import io.opentracing.tag.AbstractTag;
+import io.opentracing.tag.Tag;
 
 /**
  * Tracer is a simple, thin interface for Span creation and propagation across arbitrary transports.
@@ -175,7 +175,7 @@ public interface Tracer {
         SpanBuilder withTag(String key, Number value);
 
         /** Same as {@link AbstractTag#set(Span, T)}, but for the span being built. */
-        <T> SpanBuilder withTag(AbstractTag<T> tag, T value);
+        <T> SpanBuilder withTag(Tag<T> tag, T value);
 
         /** Specify a timestamp of when the Span was started, represented in microseconds since epoch. */
         SpanBuilder withStartTimestamp(long microseconds);

--- a/opentracing-api/src/main/java/io/opentracing/tag/AbstractTag.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/AbstractTag.java
@@ -27,5 +27,6 @@ public abstract class AbstractTag<T> implements Tag<T> {
         return key;
     }
 
-    protected abstract void set(Span span, T tagValue);
+    @Override
+    public abstract void set(Span span, T tagValue);
 }

--- a/opentracing-api/src/main/java/io/opentracing/tag/Tag.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/Tag.java
@@ -15,17 +15,6 @@ package io.opentracing.tag;
 
 import io.opentracing.Span;
 
-public abstract class AbstractTag<T> implements Tag<T> {
-    protected final String key;
-
-    public AbstractTag(String tagKey) {
-        this.key = tagKey;
-    }
-
-    @Override
-    public String getKey() {
-        return key;
-    }
-
-    protected abstract void set(Span span, T tagValue);
+public interface Tag<T> {
+    String getKey();
 }

--- a/opentracing-api/src/main/java/io/opentracing/tag/Tag.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/Tag.java
@@ -17,4 +17,5 @@ import io.opentracing.Span;
 
 public interface Tag<T> {
     String getKey();
+    void set(Span span, T value);
 }

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
@@ -16,7 +16,9 @@ package io.opentracing.mock;
 import io.opentracing.References;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
-import io.opentracing.tag.AbstractTag;
+import io.opentracing.tag.BooleanTag;
+import io.opentracing.tag.IntTag;
+import io.opentracing.tag.StringTag;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -137,8 +139,18 @@ public final class MockSpan implements Span {
     }
 
     @Override
-    public <T> Span setTag(AbstractTag<T> key, T value) {
-        return setObjectTag(key.getKey(), value);
+    public Span setTag(BooleanTag tag, Boolean value) {
+        return setObjectTag(tag.getKey(), value);
+    }
+
+    @Override
+    public Span setTag(IntTag tag, Integer value) {
+        return setObjectTag(tag.getKey(), value);
+    }
+
+    @Override
+    public Span setTag(StringTag tag, String value) {
+        return setObjectTag(tag.getKey(), value);
     }
 
     private synchronized MockSpan setObjectTag(String key, Object value) {

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
@@ -16,9 +16,7 @@ package io.opentracing.mock;
 import io.opentracing.References;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
-import io.opentracing.tag.BooleanTag;
-import io.opentracing.tag.IntTag;
-import io.opentracing.tag.StringTag;
+import io.opentracing.tag.Tag;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -139,17 +137,7 @@ public final class MockSpan implements Span {
     }
 
     @Override
-    public Span setTag(BooleanTag tag, Boolean value) {
-        return setObjectTag(tag.getKey(), value);
-    }
-
-    @Override
-    public Span setTag(IntTag tag, Integer value) {
-        return setObjectTag(tag.getKey(), value);
-    }
-
-    @Override
-    public Span setTag(StringTag tag, String value) {
+    public <T> MockSpan setTag(Tag<T> tag, T value) {
         return setObjectTag(tag.getKey(), value);
     }
 

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockSpan.java
@@ -138,7 +138,8 @@ public final class MockSpan implements Span {
 
     @Override
     public <T> MockSpan setTag(Tag<T> tag, T value) {
-        return setObjectTag(tag.getKey(), value);
+        tag.set(this, value);
+        return this;
     }
 
     private synchronized MockSpan setObjectTag(String key, Object value) {

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -34,7 +34,7 @@ import io.opentracing.noop.NoopScopeManager;
 import io.opentracing.propagation.Binary;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
-import io.opentracing.tag.AbstractTag;
+import io.opentracing.tag.Tag;
 import io.opentracing.util.ThreadLocalScopeManager;
 
 /**
@@ -348,7 +348,7 @@ public class MockTracer implements Tracer {
         }
 
         @Override
-        public <T> Tracer.SpanBuilder withTag(AbstractTag<T> tag, T value) {
+        public <T> Tracer.SpanBuilder withTag(Tag<T> tag, T value) {
             this.initialTags.put(tag.getKey(), value);
             return this;
         }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
@@ -15,7 +15,9 @@ package io.opentracing.noop;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
-import io.opentracing.tag.AbstractTag;
+import io.opentracing.tag.BooleanTag;
+import io.opentracing.tag.IntTag;
+import io.opentracing.tag.StringTag;
 
 import java.util.Map;
 
@@ -44,9 +46,13 @@ final class NoopSpanImpl implements NoopSpan {
     public NoopSpan setTag(String key, Number value) { return this; }
 
     @Override
-    public <T> Span setTag(AbstractTag<T> key, T value) {
-        return this;
-    }
+    public Span setTag(BooleanTag tag, Boolean value) { return this; }
+
+    @Override
+    public Span setTag(IntTag tag, Integer value) { return this; }
+
+    @Override
+    public Span setTag(StringTag tag, String value) { return this; }
 
     @Override
     public NoopSpan log(Map<String, ?> fields) { return this; }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
@@ -15,9 +15,7 @@ package io.opentracing.noop;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
-import io.opentracing.tag.BooleanTag;
-import io.opentracing.tag.IntTag;
-import io.opentracing.tag.StringTag;
+import io.opentracing.tag.Tag;
 
 import java.util.Map;
 
@@ -46,13 +44,7 @@ final class NoopSpanImpl implements NoopSpan {
     public NoopSpan setTag(String key, Number value) { return this; }
 
     @Override
-    public Span setTag(BooleanTag tag, Boolean value) { return this; }
-
-    @Override
-    public Span setTag(IntTag tag, Integer value) { return this; }
-
-    @Override
-    public Span setTag(StringTag tag, String value) { return this; }
+    public <T> NoopSpan setTag(Tag<T> tag, T value) { return this; }
 
     @Override
     public NoopSpan log(Map<String, ?> fields) { return this; }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
@@ -17,7 +17,7 @@ import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.tag.AbstractTag;
+import io.opentracing.tag.Tag;
 
 public interface NoopSpanBuilder extends Tracer.SpanBuilder {
     NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
@@ -59,7 +59,7 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
     }
 
     @Override
-    public <T> Tracer.SpanBuilder withTag(AbstractTag<T> key, T value) {
+    public <T> Tracer.SpanBuilder withTag(Tag<T> key, T value) {
         return this;
     }
 


### PR DESCRIPTION
This is done to not use an abstract class for our public API,
so we take overloads of BooleanTag, IntTag and StringTag.

Addresses a small detail mentioned in #314 

@yurishkuro @tylerbenson 