### PR TITLE
Add ScopeManager#activate(SpanContext)

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -32,6 +32,11 @@ public interface Tracer {
     Span activeSpan();
 
     /**
+     * @return the active {@link SpanContext}. This is a shorthand for {@code Tracer.scopeManager().activeSpanContext()}.
+     */
+    SpanContext activeSpanContext();
+
+    /**
      * Make a {@link Span} instance active for the current context (usually a thread).
      * This is a shorthand for {@code Tracer.scopeManager().activate(span)}.
      *
@@ -40,6 +45,18 @@ public interface Tracer {
      * and it may lead to memory leaks as the {@link Scope} may remain in the thread-local stack.
      */
     Scope activateSpan(Span span);
+
+
+    /**
+     * Make a {@link SpanContext} instance active for the current context (usually a thread).
+     * This is a shorthand for {@code Tracer.scopeManager().activate(spanContext)}.
+     *
+     * @see {@link ScopeManager#activate(SpanContext)}
+     * @return a {@link Scope} instance to control the end of the active period for the {@link SpanContext}. It is a
+     * programming error to neglect to call {@link Scope#close()} on the returned instance,
+     * and it may lead to memory leaks as the {@link Scope} may remain in the thread-local stack.
+     */
+    Scope activateSpanContext(SpanContext spanContext);
 
     /**
      * Return a new SpanBuilder for a Span with the given `operationName`.

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -30,7 +30,6 @@ import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.noop.NoopScopeManager;
 import io.opentracing.propagation.Binary;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
@@ -277,18 +276,19 @@ public class MockTracer implements Tracer {
         return this.scopeManager.activate(span);
     }
 
+    @Override
+    public Scope activateSpanContext(SpanContext spanContext) {
+        return this.scopeManager.activate(spanContext);
+    }
+
     synchronized void appendFinishedSpan(MockSpan mockSpan) {
         this.finishedSpans.add(mockSpan);
         this.onSpanFinished(mockSpan);
     }
 
-    private SpanContext activeSpanContext() {
-        Span span = activeSpan();
-        if (span == null) {
-            return null;
-        }
-
-        return span.context();
+    @Override
+    public SpanContext activeSpanContext() {
+        return scopeManager.activeSpanContext();
     }
 
     public final class SpanBuilder implements Tracer.SpanBuilder {

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -262,6 +262,23 @@ public class MockTracerTest {
     }
 
     @Test
+    public void testActiveSpanContext() {
+        MockTracer mockTracer = new MockTracer();
+        Assert.assertNull(mockTracer.activeSpan());
+        Assert.assertNull(mockTracer.activeSpanContext());
+
+        Span span = mockTracer.buildSpan("foo").start();
+        try (Scope scope = mockTracer.activateSpanContext(span.context())) {
+            Assert.assertNull(mockTracer.activeSpan());
+            Assert.assertEquals(mockTracer.scopeManager().activeSpanContext(), mockTracer.activeSpanContext());
+        }
+
+        Assert.assertNull(mockTracer.activeSpan());
+        Assert.assertNull(mockTracer.activeSpanContext());
+        Assert.assertTrue(mockTracer.finishedSpans().isEmpty());
+    }
+
+    @Test
     public void testActiveSpanFinish() {
         MockTracer mockTracer = new MockTracer();
         Assert.assertNull(mockTracer.activeSpan());

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
@@ -16,6 +16,7 @@ package io.opentracing.noop;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
+import io.opentracing.SpanContext;
 
 public interface NoopScopeManager extends ScopeManager {
     NoopScopeManager INSTANCE = new NoopScopeManagerImpl();
@@ -40,6 +41,11 @@ class NoopScopeManagerImpl implements NoopScopeManager {
     }
 
     @Override
+    public Scope activate(SpanContext spanContext) {
+        return NoopScope.INSTANCE;
+    }
+
+    @Override
     public Scope active() {
         return NoopScope.INSTANCE;
     }
@@ -47,6 +53,11 @@ class NoopScopeManagerImpl implements NoopScopeManager {
     @Override
     public Span activeSpan() {
         return NoopSpan.INSTANCE;
+    }
+
+    @Override
+    public SpanContext activeSpanContext() {
+        return NoopSpanContextImpl.INSTANCE;
     }
 
     static class NoopScopeImpl implements NoopScopeManager.NoopScope {

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
@@ -37,7 +37,17 @@ final class NoopTracerImpl implements NoopTracer {
     }
 
     @Override
+    public SpanContext activeSpanContext() {
+        return NoopSpanContextImpl.INSTANCE;
+    }
+
+    @Override
     public Scope activateSpan(Span span) {
+        return NoopScopeManager.NoopScope.INSTANCE;
+    }
+
+    @Override
+    public Scope activateSpanContext(SpanContext spanContext) {
         return NoopScopeManager.NoopScope.INSTANCE;
     }
 

--- a/opentracing-testbed/pom.xml
+++ b/opentracing-testbed/pom.xml
@@ -28,6 +28,7 @@
     <description>OpenTracing Testbed</description>
 
     <properties>
+        <main.java.version>1.8</main.java.version>
         <main.basedir>${project.basedir}/..</main.basedir>
     </properties>
 

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/TestUtils.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/TestUtils.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestUtils {
 
@@ -90,9 +91,8 @@ public class TestUtils {
 
     public static void assertSameTrace(List<MockSpan> spans) {
         for (int i = 0; i < spans.size() - 1; i++) {
-            assertEquals(true, spans.get(spans.size() - 1).finishMicros() >= spans.get(i).finishMicros());
+            assertTrue(spans.get(spans.size() - 1).finishMicros() >= spans.get(i).finishMicros());
             assertEquals(spans.get(spans.size() - 1).context().traceId(), spans.get(i).context().traceId());
-            assertEquals(spans.get(spans.size() - 1).context().spanId(), spans.get(i).parentId());
         }
     }
 }

--- a/opentracing-testbed/src/test/java/io/opentracing/testbed/early_span_finish/EarlySpanFinishTest.java
+++ b/opentracing-testbed/src/test/java/io/opentracing/testbed/early_span_finish/EarlySpanFinishTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.testbed.early_span_finish;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockTracer.Propagator;
+import io.opentracing.util.ThreadLocalScopeManager;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static io.opentracing.testbed.TestUtils.assertSameTrace;
+import static io.opentracing.testbed.TestUtils.sleep;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class EarlySpanFinishTest {
+
+    private final MockTracer tracer = new MockTracer(new ThreadLocalScopeManager(),
+            Propagator.TEXT_MAP);
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    @Test
+    public void test() throws Exception {
+        // Create a Span manually and use it as parent of a pair of subtasks
+        Span parentSpan = tracer.buildSpan("parent").start();
+        submitTasks(parentSpan);
+
+        // Early-finish the parent Span now
+        parentSpan.finish();
+
+        // Wait for the threadpool to be done first, instead of polling/waiting
+        executor.shutdown();
+        executor.awaitTermination(15, TimeUnit.SECONDS);
+
+
+        List<MockSpan> spans = tracer.finishedSpans();
+        assertEquals(3, spans.size());
+        assertEquals("parent", spans.get(0).operationName());
+        assertEquals(1, spans.get(0).generatedErrors().size());
+        assertEquals("task1", spans.get(1).operationName());
+        assertEquals("task2", spans.get(2).operationName());
+        assertSameTrace(spans);
+
+        assertNull(tracer.scopeManager().active());
+    }
+
+
+    /**
+     * Fire away a few subtasks, passing a parent Span whose lifetime
+     * is not tied at-all to the children
+     */
+    private void submitTasks(final Span parentSpan) {
+
+        executor.submit(new Runnable() {
+            @Override
+            public void run() {
+                // Activating the parent span is illegal as we don't have control over its life cycle.
+                // The caller of tracer.activeSpan() has no way of knowing whether the active span is already finished.
+                try (Scope scope = tracer.scopeManager().activate(parentSpan)) {
+                    Span childSpan = tracer.buildSpan("task1").start();
+                    try (Scope childScope = tracer.scopeManager().activate(childSpan)) {
+                        sleep(55);
+                        childSpan.setTag("foo", "bar");
+                    } finally {
+                        childSpan.finish();
+                    }
+                    assertNotNull(tracer.activeSpan());
+                    // this fails as the parent span is already finished
+                    tracer.activeSpan().setTag("foo", "bar");
+                }
+            }
+        });
+
+        executor.submit(new Runnable() {
+            @Override
+            public void run() {
+                // We don't own the lifecycle of the parent span,
+                // therefore we must activate the span context
+                // tracer.activeSpan() will then always return null to make the intention clear
+                // that interacting with the parent span is not possible.
+                // This puts the burden of being aware of the lifecycle to the person writing the instrumentation
+                // (for example io.opentracing.contrib.concurrent.TracedRunnable)
+                // instead of the end users, who only want to customize spans.
+                try (Scope scope = tracer.scopeManager().activate(parentSpan.context())) {
+                    Span childSpan = tracer.buildSpan("task2").start();
+                    try (Scope childScope = tracer.scopeManager().activate(childSpan)) {
+                        sleep(85);
+                        childSpan.setTag("foo", "bar");
+                    } finally {
+                        childSpan.finish();
+                    }
+                    assertNull(tracer.activeSpan());
+                    assertNotNull(tracer.activeSpanContext());
+                }
+            }
+        });
+    }
+
+}
+

--- a/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/AutoFinishScopeManager.java
@@ -13,8 +13,10 @@
  */
 package io.opentracing.util;
 
+import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
+import io.opentracing.SpanContext;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -32,6 +34,11 @@ public class AutoFinishScopeManager implements ScopeManager {
     }
 
     @Override
+    public Scope activate(SpanContext spanContext) {
+        return new AutoFinishScope(this, spanContext);
+    }
+
+    @Override
     public AutoFinishScope active() {
         return tlsScope.get();
     }
@@ -40,5 +47,11 @@ public class AutoFinishScopeManager implements ScopeManager {
     public Span activeSpan() {
         AutoFinishScope scope = tlsScope.get();
         return scope == null ? null : scope.span();
+    }
+
+    @Override
+    public SpanContext activeSpanContext() {
+        AutoFinishScope scope = tlsScope.get();
+        return scope == null ? null : scope.spanContext();
     }
 }

--- a/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
@@ -180,8 +180,18 @@ public final class GlobalTracer implements Tracer {
     }
 
     @Override
+    public SpanContext activeSpanContext() {
+        return tracer.activeSpanContext();
+    }
+
+    @Override
     public Scope activateSpan(Span span) {
         return tracer.activateSpan(span);
+    }
+
+    @Override
+    public Scope activateSpanContext(SpanContext spanContext) {
+        return tracer.activateSpanContext(spanContext);
     }
 
     @Override

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScope.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScope.java
@@ -16,6 +16,7 @@ package io.opentracing.util;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
+import io.opentracing.SpanContext;
 
 /**
  * {@link ThreadLocalScope} is a simple {@link Scope} implementation that relies on Java's
@@ -28,16 +29,26 @@ public class ThreadLocalScope implements Scope {
     private final Span wrapped;
     private final boolean finishOnClose;
     private final ThreadLocalScope toRestore;
+    private final SpanContext spanContext;
 
     ThreadLocalScope(ThreadLocalScopeManager scopeManager, Span wrapped) {
-        this(scopeManager, wrapped, false);
+        this(scopeManager, wrapped, null, false);
+    }
+
+    ThreadLocalScope(ThreadLocalScopeManager scopeManager, SpanContext spanContext) {
+        this(scopeManager, null, spanContext, false);
     }
 
     ThreadLocalScope(ThreadLocalScopeManager scopeManager, Span wrapped, boolean finishOnClose) {
+        this(scopeManager, wrapped, null, finishOnClose);
+    }
+
+    private ThreadLocalScope(ThreadLocalScopeManager scopeManager, Span wrapped, SpanContext spanContext, boolean finishOnClose) {
         this.scopeManager = scopeManager;
         this.wrapped = wrapped;
         this.finishOnClose = finishOnClose;
         this.toRestore = scopeManager.tlsScope.get();
+        this.spanContext = spanContext;
         scopeManager.tlsScope.set(this);
     }
 
@@ -58,5 +69,9 @@ public class ThreadLocalScope implements Scope {
     @Override
     public Span span() {
         return wrapped;
+    }
+
+    SpanContext spanContext() {
+        return wrapped != null ? wrapped.context() : spanContext;
     }
 }

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
@@ -16,6 +16,7 @@ package io.opentracing.util;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
+import io.opentracing.SpanContext;
 
 /**
  * A simple {@link ScopeManager} implementation built on top of Java's thread-local storage primitive.
@@ -36,6 +37,11 @@ public class ThreadLocalScopeManager implements ScopeManager {
     }
 
     @Override
+    public Scope activate(SpanContext spanContext) {
+        return new ThreadLocalScope(this, spanContext);
+    }
+
+    @Override
     public Scope active() {
         return tlsScope.get();
     }
@@ -44,5 +50,11 @@ public class ThreadLocalScopeManager implements ScopeManager {
     public Span activeSpan() {
         Scope scope = tlsScope.get();
         return scope == null ? null : scope.span();
+    }
+
+    @Override
+    public SpanContext activeSpanContext() {
+        ThreadLocalScope scope = tlsScope.get();
+        return scope == null ? null : scope.spanContext();
     }
 }


### PR DESCRIPTION
Similar to `ScopeManager#activate(Span)` but used in cases where the thread in which the activation is performed does not have control over the life cycle of the span.

This puts the burden of being aware of the lifecycle to the one writing the instrumentation (for example [`TracedRunnable`](https://github.com/opentracing-contrib/java-concurrent/blob/master/src/main/java/io/opentracing/contrib/concurrent/TracedRunnable.java)) instead of the user of `Tracer.activeSpan()`. The `EarlySpanFinishTest` demonstrates this.

It also simplifies tracer implementations as with this change tracers don't have to guard against racy calls to `Span#finish()` and `ScopeManager#activate(Span)`. This is really painful to do if the tracer implementation relies on no methods being called on the span after `finish()` (for example when the tracer recycles the span object).

This addresses the problems laid out in https://github.com/opentracing/opentracing-java/issues/312