### PR TITLE
Initial implementation of a no-op active Span.

### DIFF
--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -30,7 +30,7 @@ import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.noop.NoopScopeManager;
+import io.opentracing.noop.NoopSpanContext;
 import io.opentracing.propagation.Binary;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
@@ -268,8 +268,7 @@ public class MockTracer implements Tracer {
 
     @Override
     public Span activeSpan() {
-        Scope scope = this.scopeManager.active();
-        return scope == null ? null : scope.span();
+        return this.scopeManager.active().span();
     }
 
     @Override
@@ -304,6 +303,9 @@ public class MockTracer implements Tracer {
 
         @Override
         public SpanBuilder asChildOf(SpanContext parent) {
+            if (parent == NoopSpanContext.INSTANCE) {
+                return  this;
+            }
             return addReference(References.CHILD_OF, parent);
         }
 
@@ -375,7 +377,7 @@ public class MockTracer implements Tracer {
                 this.startMicros = MockSpan.nowMicros();
             }
             SpanContext activeSpanContext = activeSpanContext();
-            if(references.isEmpty() && !ignoringActiveSpan && activeSpanContext != null) {
+            if(references.isEmpty() && !ignoringActiveSpan && activeSpanContext != NoopSpanContext.INSTANCE) {
                 references.add(new MockSpan.Reference((MockSpan.MockContext) activeSpanContext, References.CHILD_OF));
             }
             return new MockSpan(MockTracer.this, operationName, startMicros, initialTags, references);

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -30,6 +30,7 @@ import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+import io.opentracing.noop.NoopSpan;
 import io.opentracing.propagation.Binary;
 import io.opentracing.propagation.BinaryAdapters;
 import io.opentracing.propagation.Format;
@@ -250,21 +251,21 @@ public class MockTracerTest {
     @Test
     public void testActiveSpan() {
         MockTracer mockTracer = new MockTracer();
-        Assert.assertNull(mockTracer.activeSpan());
+        Assert.assertEquals(NoopSpan.INSTANCE, mockTracer.activeSpan());
 
         Span span = mockTracer.buildSpan("foo").start();
         try (Scope scope = mockTracer.activateSpan(span)) {
             Assert.assertEquals(mockTracer.scopeManager().activeSpan(), mockTracer.activeSpan());
         }
 
-        Assert.assertNull(mockTracer.activeSpan());
+        Assert.assertEquals(NoopSpan.INSTANCE, mockTracer.activeSpan());
         Assert.assertTrue(mockTracer.finishedSpans().isEmpty());
     }
 
     @Test
     public void testActiveSpanFinish() {
         MockTracer mockTracer = new MockTracer();
-        Assert.assertNull(mockTracer.activeSpan());
+        Assert.assertEquals(NoopSpan.INSTANCE, mockTracer.activeSpan());
 
         Scope scope = null;
         try {
@@ -274,7 +275,7 @@ public class MockTracerTest {
             scope.close();
         }
 
-        Assert.assertNull(mockTracer.activeSpan());
+        Assert.assertEquals(NoopSpan.INSTANCE, mockTracer.activeSpan());
         Assert.assertFalse(mockTracer.finishedSpans().isEmpty());
     }
 

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopScope.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopScope.java
@@ -13,34 +13,19 @@
  */
 package io.opentracing.noop;
 
-import io.opentracing.SpanContext;
+import io.opentracing.Scope;
+import io.opentracing.Span;
 
-import java.util.Collections;
-import java.util.Map;
-
-
-public interface NoopSpanContext extends SpanContext {
-    static final NoopSpanContextImpl INSTANCE = new NoopSpanContextImpl();
+public interface NoopScope extends Scope {
+    NoopScope INSTANCE = new NoopScopeImpl();
 }
 
-final class NoopSpanContextImpl implements NoopSpanContext {
+class NoopScopeImpl implements NoopScope {
+    @Override
+    public void close() {}
 
     @Override
-    public String toTraceId() {
-        return "";
+    public Span span() {
+        return NoopSpan.INSTANCE;
     }
-
-    @Override
-    public String toSpanId() {
-        return "";
-    }
-
-    @Override
-    public Iterable<Map.Entry<String, String>> baggageItems() {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public String toString() { return NoopSpanContext.class.getSimpleName(); }
-
 }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopScopeManager.java
@@ -19,10 +19,6 @@ import io.opentracing.Span;
 
 public interface NoopScopeManager extends ScopeManager {
     NoopScopeManager INSTANCE = new NoopScopeManagerImpl();
-
-    interface NoopScope extends Scope {
-        NoopScope INSTANCE = new NoopScopeManagerImpl.NoopScopeImpl();
-    }
 }
 
 /**
@@ -47,15 +43,5 @@ class NoopScopeManagerImpl implements NoopScopeManager {
     @Override
     public Span activeSpan() {
         return NoopSpan.INSTANCE;
-    }
-
-    static class NoopScopeImpl implements NoopScopeManager.NoopScope {
-        @Override
-        public void close() {}
-
-        @Override
-        public Span span() {
-            return NoopSpan.INSTANCE;
-        }
     }
 }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java
@@ -26,7 +26,7 @@ public interface NoopSpan extends Span {
 final class NoopSpanImpl implements NoopSpan {
 
     @Override
-    public SpanContext context() { return NoopSpanContextImpl.INSTANCE; }
+    public SpanContext context() { return NoopSpanContext.INSTANCE; }
 
     @Override
     public void finish() {}

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpanBuilder.java
@@ -70,7 +70,7 @@ final class NoopSpanBuilderImpl implements NoopSpanBuilder {
 
     @Override
     public Scope startActive(boolean finishOnClose) {
-        return NoopScopeManager.NoopScope.INSTANCE;
+        return NoopScope.INSTANCE;
     }
 
     @Override

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
@@ -38,7 +38,7 @@ final class NoopTracerImpl implements NoopTracer {
 
     @Override
     public Scope activateSpan(Span span) {
-        return NoopScopeManager.NoopScope.INSTANCE;
+        return NoopScope.INSTANCE;
     }
 
     @Override

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
@@ -16,6 +16,8 @@ package io.opentracing.util;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
+import io.opentracing.noop.NoopScope;
+import io.opentracing.noop.NoopSpan;
 
 /**
  * A simple {@link ScopeManager} implementation built on top of Java's thread-local storage primitive.
@@ -37,12 +39,12 @@ public class ThreadLocalScopeManager implements ScopeManager {
 
     @Override
     public Scope active() {
-        return tlsScope.get();
+        Scope scope = tlsScope.get();
+        return scope == null ? NoopScope.INSTANCE : scope;
     }
 
     @Override
     public Span activeSpan() {
-        Scope scope = tlsScope.get();
-        return scope == null ? null : scope.span();
+        return active().span();
     }
 }

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeManagerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeManagerTest.java
@@ -15,6 +15,8 @@ package io.opentracing.util;
 
 import io.opentracing.Scope;
 import io.opentracing.Span;
+import io.opentracing.noop.NoopScope;
+import io.opentracing.noop.NoopSpan;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,13 +37,13 @@ public class ThreadLocalScopeManagerTest {
     @Test
     public void missingActiveScope() throws Exception {
         Scope missingScope = source.active();
-        assertNull(missingScope);
+        assertEquals(NoopScope.INSTANCE, missingScope);
     }
 
     @Test
     public void missingActiveSpan() throws Exception {
         Span missingSpan = source.activeSpan();
-        assertNull(missingSpan);
+        assertEquals(NoopSpan.INSTANCE, missingSpan);
     }
 
     @Test
@@ -65,10 +67,10 @@ public class ThreadLocalScopeManagerTest {
 
         // And now Scope/Span are gone:
         Scope missingScope = source.active();
-        assertNull(missingScope);
+        assertEquals(NoopScope.INSTANCE, missingScope);
 
         Span missingSpan = source.activeSpan();
-        assertNull(missingSpan);
+        assertEquals(NoopSpan.INSTANCE, missingSpan);
     }
 
     @Test
@@ -89,8 +91,8 @@ public class ThreadLocalScopeManagerTest {
         verify(span, times(1)).finish();
 
         // Verify Scope/Span are gone.
-        assertNull(source.active());
-        assertNull(source.activeSpan());
+        assertEquals(NoopScope.INSTANCE, source.active());
+        assertEquals(NoopSpan.INSTANCE, source.activeSpan());
     }
 
     @Test
@@ -111,7 +113,7 @@ public class ThreadLocalScopeManagerTest {
         verify(span, never()).finish();
 
         // Verify Scope/Span are gone.
-        assertNull(source.active());
-        assertNull(source.activeSpan());
+        assertEquals(NoopScope.INSTANCE, source.active());
+        assertEquals(NoopSpan.INSTANCE, source.activeSpan());
     }
 }

--- a/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/ThreadLocalScopeTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 
 import io.opentracing.Scope;
 import io.opentracing.Span;
+import io.opentracing.noop.NoopScope;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -64,7 +65,7 @@ public class ThreadLocalScopeTest {
 
         // And now nothing is active.
         Scope missingSpan = scopeManager.active();
-        assertNull(missingSpan);
+        assertEquals(NoopScope.INSTANCE, missingSpan);
     }
 
     @Test


### PR DESCRIPTION
Hey all,

I decided to test out, as a prototype, a no-op active `Scope`/`Span` for the current api. This had been suggested (or at least mentioned) in the past. And it could probably help with features such as #319 

Advantages:
* Never have to check for null on `ScopeManager.active()` nor `ScopeManager.activeSpan()`.

Potential issues:
* Tracers need to be aware of this feature - see the code in `MockTracer` which will check against `NoopSpanContext`, and which case it will ignore it as potential parent when creating new `Span`s.
* Test writers might need to check against the same -, i.e. `assertEquals(NoopScope.INSTANCE, scopeManager.active())` instead of `assertNull(scopeManager.active())`.

Thoughts? 

@yurishkuro @felixbarny @tedsuo @sjoerdtalsma @tylerbenson @opentracing/opentracing-java-maintainers 

PS - Did not update the testbed module. Will do that later if we decide to go on and merge this change ;)