### PR TITLE
Make Tracer extends Closable.

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -130,6 +130,7 @@ public interface Tracer extends Closeable {
      * <p>
      * For stateless tracers, this can be a no-op.
      */
+    @Override
     void close();
 
     interface SpanBuilder {

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -120,12 +120,13 @@ public interface Tracer extends Closeable {
     <C> SpanContext extract(Format<C> format, C carrier);
 
     /**
-     * Closes the Tracer, and flushes the in-memory collection to the configured persistance store.
+     * Closes the Tracer, and tries to flush the in-memory collection to the configured persistance store.
      *
      * <p>
      * The close method should be considered idempotent; closing an already closed Tracer should not raise an error.
      * Spans that are created or finished after a Tracer has been closed may or may not be flushed.
-     * Calling the close method should be considered a synchronous operation.
+     * Calling the close method should be considered a synchronous operation. Observe this call may block for
+     * a relatively long period of time, depending on the internal shutdown.
      * <p>
      * For stateless tracers, this can be a no-op.
      */

--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -13,13 +13,15 @@
  */
 package io.opentracing;
 
+import java.io.Closeable;
+
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tag;
 
 /**
  * Tracer is a simple, thin interface for Span creation and propagation across arbitrary transports.
  */
-public interface Tracer {
+public interface Tracer extends Closeable {
 
     /**
      * @return the current {@link ScopeManager}, which may be a noop but may not be null.
@@ -117,6 +119,17 @@ public interface Tracer {
      */
     <C> SpanContext extract(Format<C> format, C carrier);
 
+    /**
+     * Closes the Tracer, and flushes the in-memory collection to the configured persistance store.
+     *
+     * <p>
+     * The close method should be considered idempotent; closing an already closed Tracer should not raise an error.
+     * Spans that are created or finished after a Tracer has been closed may or may not be flushed.
+     * Calling the close method should be considered a synchronous operation.
+     * <p>
+     * For stateless tracers, this can be a no-op.
+     */
+    void close();
 
     interface SpanBuilder {
 

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -24,7 +24,6 @@ import java.io.ObjectOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -24,6 +24,7 @@ import java.io.ObjectOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +54,7 @@ public class MockTracer implements Tracer {
     private final List<MockSpan> finishedSpans = new ArrayList<>();
     private final Propagator propagator;
     private final ScopeManager scopeManager;
+    private boolean isClosed;
 
     public MockTracer() {
         this(new ThreadLocalScopeManager(), Propagator.TEXT_MAP);
@@ -280,7 +282,16 @@ public class MockTracer implements Tracer {
         return this.scopeManager.activate(span);
     }
 
+    @Override
+    public synchronized void close() {
+        this.isClosed = true;
+        this.finishedSpans.clear();
+    }
+
     synchronized void appendFinishedSpan(MockSpan mockSpan) {
+        if (isClosed)
+            return;
+
         this.finishedSpans.add(mockSpan);
         this.onSpanFinished(mockSpan);
     }

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -399,4 +399,16 @@ public class MockTracerTest {
         Span span = tracer.buildSpan("foo").asChildOf(parent).start();
         span.finish();
     }
+
+    @Test
+    public void testClose() {
+        MockTracer mockTracer = new MockTracer();
+        mockTracer.buildSpan("foo").start().finish();
+
+        mockTracer.close();
+        assertEquals(0, mockTracer.finishedSpans().size());
+
+        mockTracer.buildSpan("foo").start().finish();
+        assertEquals(0, mockTracer.finishedSpans().size());
+    }
 }

--- a/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
+++ b/opentracing-noop/src/main/java/io/opentracing/noop/NoopTracer.java
@@ -51,6 +51,9 @@ final class NoopTracerImpl implements NoopTracer {
     public <C> SpanContext extract(Format<C> format, C carrier) { return NoopSpanContextImpl.INSTANCE; }
 
     @Override
+    public void close() {}
+
+    @Override
     public String toString() { return NoopTracer.class.getSimpleName(); }
 }
 

--- a/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
@@ -22,6 +22,7 @@ import io.opentracing.noop.NoopTracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.opentracing.propagation.Format;
 
+import java.io.IOException;
 import java.util.concurrent.Callable;
 
 /**
@@ -212,6 +213,11 @@ public final class GlobalTracer implements Tracer {
     @Override
     public Scope activateSpan(Span span) {
         return tracer.activateSpan(span);
+    }
+
+    @Override
+    public void close() {
+        tracer.close();
     }
 
     @Override

--- a/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
@@ -22,7 +22,6 @@ import io.opentracing.noop.NoopTracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.opentracing.propagation.Format;
 
-import java.io.IOException;
 import java.util.concurrent.Callable;
 
 /**

--- a/opentracing-util/src/test/java/io/opentracing/util/GlobalTracerTest.java
+++ b/opentracing-util/src/test/java/io/opentracing/util/GlobalTracerTest.java
@@ -45,6 +45,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -223,6 +224,16 @@ public class GlobalTracerTest {
 
         verify(mockTracer).extract(eq(mockFormat), eq(mockCarrier));
         verifyNoMoreInteractions(mockTracer, mockFormat, mockCarrier);
+    }
+
+    @Test
+    public void testDelegation_close() {
+        Tracer mockTracer = mock(Tracer.class);
+        GlobalTracer.register(mockTracer);
+        GlobalTracer.get().close();
+
+        verify(mockTracer, times(1)).close();
+        verifyNoMoreInteractions(mockTracer);
     }
 
     @Test


### PR DESCRIPTION
Prior to 0.32, I decided to take a shot at this feature (as part of https://github.com/opentracing/specification/issues/130) - the change itself is actually minimal, and I'm guessing that this could be an easy-to-implement item for Tracer maintainers, but would definitely love some feedback.

Depending on how good or bad the changes are deemed, we might include this in the 0.32 Final Release ;)

PS - Was tempted to leave `MockTracer.close()` as no-op, but preferred to keep the invariant.

@yurishkuro @tylerbenson @austinlparker  @opentracing/opentracing-java-maintainers 