### PR TITLE
V0.32.0 README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ In practice, all of this is most fluently accomplished through the use of an Ope
 `ScopeManager.active(Span, boolean)` and `SpanBuilder.startActive()` have been deprecated as part of removing automatic `Span` finish upon `Scope` close, as doing it through try-with statements would make it hard to properly handle errors (`Span` objects would get finished before a catch block would be reached).
 This improves API safety, and makes it more difficult to do the wrong thing and end up with unexpected errors.
 
-`Scope.span()` and `ScopeManager.scope()` have been deprecated in order to prevent passing of `Scope` objects between threads (`Scope` objects are not guaranteed to be thread-safe).
+`Scope.span()` and `ScopeManager.scope()` have been deprecated in order to prevent the anti-pattern of passing `Scope` objects between threads (`Scope` objects are not guaranteed to be thread-safe).
 Now `Scope` will be responsible for `Span` deactivation only, instead of being a `Span` container.
 
 ## Instrumentation Tests

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ In practice, all of this is most fluently accomplished through the use of an Ope
 
 ## Deprecated members since 0.31
 
-`ScopeManager.active(Span, boolean)` and `SpanBuilder.startActive()` have been deprecated as part of removing automatic `Span` finish upon `Scope` closing, as doing it through try-with statements would make it hard to properly handle errors (`Span` objects would get finished before a catch block would be reached).
+`ScopeManager.active(Span, boolean)` and `SpanBuilder.startActive()` have been deprecated as part of removing automatic `Span` finish upon `Scope` close, as doing it through try-with statements would make it hard to properly handle errors (`Span` objects would get finished before a catch block would be reached).
 This improves API safety, and makes it more difficult to do the wrong thing and end up with unexpected errors.
 
 `Scope.span()` and `ScopeManager.scope()` have been deprecated, in order to prevent passing of `Scope` objects between threads (`Scope` objects are not guaranteed to be thread-safe).

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ try (Scope scope = tracer.scopeManager().activate(span)) {
         }
     }).thenRun(() -> {
         // STEP 3 ABOVE: finish the Span when the work is done.
+        span.finish();
     });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ That said, instrumentation for packages that are themselves statically configure
 
 For any thread, at most one `Span` may be "active". Of course there may be many other `Spans` involved with the thread which are (a) started, (b) not finished, and yet (c) not "active": perhaps they are waiting for I/O, blocked on a child Span, or otherwise off of the critical path.
  
-It's inconvenient to pass an active `Span` from function to function manually, so OpenTracing requires that every `Tracer` contains a `ScopeManager` that grants access to the active `Span` through a `Scope`. Any `Span` may be transferred to another callback or thread, but not `Scope`; more on this below.
+It's inconvenient to pass an active `Span` from function to function manually, so OpenTracing requires that every `Tracer` contains a `ScopeManager` that grants access to the active `Span` along with a `Scope` to signal deactivation. Any `Span` may be transferred to another callback or thread, but not `Scope`; more on this below.
 
 #### Accessing the active Span
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ In practice, all of this is most fluently accomplished through the use of an Ope
 `ScopeManager.active(Span, boolean)` and `SpanBuilder.startActive()` have been deprecated as part of removing automatic `Span` finish upon `Scope` close, as doing it through try-with statements would make it hard to properly handle errors (`Span` objects would get finished before a catch block would be reached).
 This improves API safety, and makes it more difficult to do the wrong thing and end up with unexpected errors.
 
-`Scope.span()` and `ScopeManager.scope()` have been deprecated, in order to prevent passing of `Scope` objects between threads (`Scope` objects are not guaranteed to be thread-safe).
+`Scope.span()` and `ScopeManager.scope()` have been deprecated in order to prevent passing of `Scope` objects between threads (`Scope` objects are not guaranteed to be thread-safe).
 Now `Scope` will be responsible for `Span` deactivation only, instead of being a `Span` container.
 
 ## Instrumentation Tests


### PR DESCRIPTION
The README is now updated with the new Scope/Span usage, as well as mention of deprecation of automatic Span finish upon Scope close (and related members).

This is done prior to do a release (finally) ;)