### PR TITLE
Do not make isRegistered() synchronized.

### DIFF
--- a/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java
@@ -95,7 +95,7 @@ public final class GlobalTracer implements Tracer {
      *
      * @return Whether a tracer has been registered
      */
-    public static synchronized boolean isRegistered() { return isRegistered; }
+    public static boolean isRegistered() { return isRegistered; }
 
     /**
      * Register a {@link Tracer} to back the behaviour of the {@link #get()}.


### PR DESCRIPTION
This one does not really need to be synchronized.
The field itself is volatile and that is enough.

Probably being too pedantic on this, but it feels this is the correct thing to do ;)

@yurishkuro @sjoerdtalsma 