### PR TITLE
#334 - Added ScopeListener interface to the ThreadLocalScopeManager

### DIFF
--- a/opentracing-util/src/main/java/io/opentracing/util/NoopScopeListener.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/NoopScopeListener.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util;
+
+import io.opentracing.Span;
+
+public interface NoopScopeListener extends ScopeListener {
+    NoopScopeListener INSTANCE = new NoopScopeListenerImpl();
+}
+
+class NoopScopeListenerImpl implements NoopScopeListener {
+
+    @Override
+    public void onActivate(Span span) {
+    }
+
+    @Override
+    public void onClose() {
+    }
+}

--- a/opentracing-util/src/main/java/io/opentracing/util/NoopScopeListener.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/NoopScopeListener.java
@@ -19,6 +19,9 @@ public interface NoopScopeListener extends ScopeListener {
     NoopScopeListener INSTANCE = new NoopScopeListenerImpl();
 }
 
+/**
+ * A noop (i.e., cheap-as-possible) implementation of a ScopeListener.
+ */
 class NoopScopeListenerImpl implements NoopScopeListener {
 
     @Override

--- a/opentracing-util/src/main/java/io/opentracing/util/ScopeListener.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ScopeListener.java
@@ -13,11 +13,32 @@
  */
 package io.opentracing.util;
 
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 
+/**
+ * Listener that can react on changes of currently active {@link Span}.
+ * <p>
+ * The {@link #onActivate(Span)} method will be called, whenever scope changes - that can be both
+ * as result of a {@link ScopeManager#activate(Span, boolean)} call or when {@link Scope#close()}
+ * is closed on a nested scope.
+ * <p>
+ * {@link #onClose()} is called when closing outermost scope - meaning no scope is currently active.
+ *
+ * @see ThreadLocalScopeManager
+ */
 public interface ScopeListener {
 
+    /**
+     * Called whenever a scope was activated (changed).
+     *
+     * @param span Activated span. Never null.
+     */
     void onActivate(Span span);
 
+    /**
+     * Called when outermost scope was deactivated.
+     */
     void onClose();
 }

--- a/opentracing-util/src/main/java/io/opentracing/util/ScopeListener.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ScopeListener.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.util;
+
+import io.opentracing.Span;
+
+public interface ScopeListener {
+
+    void onActivate(Span span);
+
+    void onClose();
+}

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScope.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScope.java
@@ -35,6 +35,7 @@ public class ThreadLocalScope implements Scope {
         this.finishOnClose = finishOnClose;
         this.toRestore = scopeManager.tlsScope.get();
         scopeManager.tlsScope.set(this);
+        scopeManager.listener.onActivate(wrapped);
     }
 
     @Override
@@ -48,7 +49,13 @@ public class ThreadLocalScope implements Scope {
             wrapped.finish();
         }
 
-        scopeManager.tlsScope.set(toRestore);
+        if (toRestore != null) {
+            scopeManager.tlsScope.set(toRestore);
+            scopeManager.listener.onActivate(toRestore.wrapped);
+        } else {
+            scopeManager.tlsScope.remove();
+            scopeManager.listener.onClose();
+        }
     }
 
     @Override

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
@@ -23,7 +23,17 @@ import io.opentracing.Span;
  * @see ThreadLocalScope
  */
 public class ThreadLocalScopeManager implements ScopeManager {
+
     final ThreadLocal<ThreadLocalScope> tlsScope = new ThreadLocal<ThreadLocalScope>();
+    final ScopeListener listener;
+
+    public ThreadLocalScopeManager() {
+        this(null);
+    }
+
+    public ThreadLocalScopeManager(ScopeListener listener) {
+        this.listener = listener != null ? listener : NoopScopeListener.INSTANCE;
+    }
 
     @Override
     public Scope activate(Span span, boolean finishOnClose) {

--- a/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
+++ b/opentracing-util/src/main/java/io/opentracing/util/ThreadLocalScopeManager.java
@@ -19,6 +19,10 @@ import io.opentracing.Span;
 
 /**
  * A simple {@link ScopeManager} implementation built on top of Java's thread-local storage primitive.
+ * <p>
+ * Optionally supports {@link ScopeListener}, to perform additional actions when scope is changed for given thread.
+ * Listener methods are always called synchronously on the same thread, right after activation (meaning {@link #active()}
+ * already returns new a scope).
  *
  * @see ThreadLocalScope
  */
@@ -27,10 +31,18 @@ public class ThreadLocalScopeManager implements ScopeManager {
     final ThreadLocal<ThreadLocalScope> tlsScope = new ThreadLocal<ThreadLocalScope>();
     final ScopeListener listener;
 
+    /**
+     * Default constructor for {@link ThreadLocalScopeManager}, without any listener.
+     */
     public ThreadLocalScopeManager() {
         this(null);
     }
 
+    /**
+     * Constructs {@link ThreadLocalScopeManager} with custom {@link ScopeListener}.
+     *
+     * @param listener Listener to register. When null, noop listener will be used.
+     */
     public ThreadLocalScopeManager(ScopeListener listener) {
         this.listener = listener != null ? listener : NoopScopeListener.INSTANCE;
     }


### PR DESCRIPTION
* Added new interface `ScopeListener`
* Modified `ThreadLocalScopeManager`
* Added `NoopScopeListener` to be used as default
* Modified tests

Is there anything else missing?

Also, I've created signature of onActivate, thaking directly span:
```
void onActivate(Span span);
```
Because consumers should not actually need the scope, only its span - but it is a little weird, having Span in the interface called ScopeListener. What do you think? I have already prepared commit to change it to `void onActivate(Scope scope);`