### PR TITLE
 Add PEER_ADDRESS tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,15 @@
 
 If you would like to contribute code you can do so through GitHub by forking the repository and sending a pull request (on a branch other than `master` or `gh-pages`).
 
-
 ## License
 
-By contributing your code, you agree to license your contribution under the terms of the APLv2: https://github.com/opentracing/opentracing-java/blob/master/LICENSE
+By contributing your code, you agree to license your contribution under the terms of the APLv2: <https://github.com/opentracing/opentracing-java/blob/master/LICENSE>
 
 All files are released with the Apache 2.0 license.
 
 If you are adding a new file it should have a header like below. This can be automatically added by running `./mvnw com.mycila:license-maven-plugin:format`.
 
-```
+```java
 /**
  * Copyright 2016-2019 The OpenTracing Authors
  *

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,16 @@
 
 If you would like to contribute code you can do so through GitHub by forking the repository and sending a pull request (on a branch other than `master` or `gh-pages`).
 
+
 ## License
 
-By contributing your code, you agree to license your contribution under the terms of the APLv2: <https://github.com/opentracing/opentracing-java/blob/master/LICENSE>
+By contributing your code, you agree to license your contribution under the terms of the APLv2: https://github.com/opentracing/opentracing-java/blob/master/LICENSE
 
 All files are released with the Apache 2.0 license.
 
 If you are adding a new file it should have a header like below. This can be automatically added by running `./mvnw com.mycila:license-maven-plugin:format`.
 
-```java
+```
 /**
  * Copyright 2016-2019 The OpenTracing Authors
  *

--- a/opentracing-api/src/main/java/io/opentracing/tag/Tags.java
+++ b/opentracing-api/src/main/java/io/opentracing/tag/Tags.java
@@ -18,7 +18,7 @@ package io.opentracing.tag;
  * semantic information about the spans. Tracers may expose additional features based on these
  * standardized data points. Tag names follow a general structure of namespacing.
  *
- * @see <a href="https://github.com/opentracing/specification/blob/master/semantic_conventions.md">https://github.com/opentracing/specification/blob/master/semantic_conventions.md</a>
+ * @see <a href="https://github.com/opentracing/specification/blob/1.1/semantic_conventions.md">OpenTracing Specification Semantic Conventions v1.1</a>
  */
 
 public final class Tags {
@@ -59,6 +59,13 @@ public final class Tags {
      * HTTP_METHOD records the http method. Case-insensitive.
      */
     public static final StringTag HTTP_METHOD = new StringTag("http.method");
+
+    /**
+     * PEER_ADDRESS records remote "address", suitable for use in a networking client library.
+     * This may be a `"ip:port"`, a bare `"hostname"`, a FQDN,
+     * or even a JDBC substring like `"mysql://prod-db:3306"`.
+     */
+    public static final StringTag PEER_ADDRESS = new StringTag("peer.address");
 
     /**
      * PEER_HOST_IPV4 records IPv4 host address of the peer.


### PR DESCRIPTION
  Add `peer.address` tag according to [OpenTracing Specification Semantic Conventions v1.1](https://github.com/opentracing/specification/blob/master/semantic_conventions.md).
