### PR TITLE
Don't override the return type in buildSpan().

### DIFF
--- a/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
+++ b/opentracing-mock/src/main/java/io/opentracing/mock/MockTracer.java
@@ -280,7 +280,7 @@ public class MockTracer implements Tracer {
     }
 
     @Override
-    public SpanBuilder buildSpan(String operationName) {
+    public Tracer.SpanBuilder buildSpan(String operationName) {
         return new SpanBuilder(operationName);
     }
 

--- a/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
+++ b/opentracing-mock/src/test/java/io/opentracing/mock/MockTracerTest.java
@@ -123,8 +123,8 @@ public class MockTracerTest {
 
         try(MockTracer tracer = new MockTracer()) {
             for (int i = 0; i < TRACE_CNT; i++) {
-                MockSpan parent = tracer.buildSpan("parent").withStartTimestamp(1000).start();
-                MockSpan child = tracer.buildSpan("child").withStartTimestamp(1100).asChildOf(parent).start();
+                MockSpan parent = (MockSpan) tracer.buildSpan("parent").withStartTimestamp(1000).start();
+                MockSpan child = (MockSpan) tracer.buildSpan("child").withStartTimestamp(1100).asChildOf(parent).start();
                 child.finish(1900);
                 parent.finish(2000);
 
@@ -305,9 +305,9 @@ public class MockTracerTest {
     @Test
     public void testFollowFromReference() {
         MockTracer tracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
-        final MockSpan precedent = tracer.buildSpan("precedent").start();
+        final MockSpan precedent = (MockSpan) tracer.buildSpan("precedent").start();
 
-        final MockSpan followingSpan = tracer.buildSpan("follows")
+        final MockSpan followingSpan = (MockSpan) tracer.buildSpan("follows")
             .addReference(References.FOLLOWS_FROM, precedent.context())
             .start();
 
@@ -322,10 +322,10 @@ public class MockTracerTest {
     @Test
     public void testMultiReferences() {
         MockTracer tracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
-        final MockSpan parent = tracer.buildSpan("parent").start();
-        final MockSpan precedent = tracer.buildSpan("precedent").start();
+        final MockSpan parent = (MockSpan) tracer.buildSpan("parent").start();
+        final MockSpan precedent = (MockSpan) tracer.buildSpan("precedent").start();
 
-        final MockSpan followingSpan = tracer.buildSpan("follows")
+        final MockSpan followingSpan = (MockSpan) tracer.buildSpan("follows")
             .addReference(References.FOLLOWS_FROM, precedent.context())
             .asChildOf(parent.context())
             .start();
@@ -343,12 +343,12 @@ public class MockTracerTest {
     @Test
     public void testMultiReferencesBaggage() {
         MockTracer tracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
-        final MockSpan parent = tracer.buildSpan("parent").start();
+        final MockSpan parent = (MockSpan) tracer.buildSpan("parent").start();
         parent.setBaggageItem("parent", "foo");
-        final MockSpan precedent = tracer.buildSpan("precedent").start();
+        final MockSpan precedent = (MockSpan) tracer.buildSpan("precedent").start();
         precedent.setBaggageItem("precedent", "bar");
 
-        final MockSpan followingSpan = tracer.buildSpan("follows")
+        final MockSpan followingSpan = (MockSpan) tracer.buildSpan("follows")
             .addReference(References.FOLLOWS_FROM, precedent.context())
             .asChildOf(parent.context())
             .start();
@@ -360,9 +360,9 @@ public class MockTracerTest {
     @Test
     public void testNonStandardReference() {
         MockTracer tracer = new MockTracer(MockTracer.Propagator.TEXT_MAP);
-        final MockSpan parent = tracer.buildSpan("parent").start();
+        final MockSpan parent = (MockSpan) tracer.buildSpan("parent").start();
 
-        final MockSpan nextSpan = tracer.buildSpan("follows")
+        final MockSpan nextSpan = (MockSpan) tracer.buildSpan("follows")
             .addReference("a_reference", parent.context())
             .start();
 


### PR DESCRIPTION
This makes it possible to override `buildSpan(String op)` of MockTracer and return another impl of `Tracer.SpanBuilder`.
A use-case for this would be, for example, to supply an instance of `SpanBuilder` that delegates to original `MockTracer.SpanBuilder`, but also performs additional logging.