### PR TITLE
docs(Tracer): remove link to nonexistent method

### DIFF
--- a/opentracing-api/src/main/java/io/opentracing/Tracer.java
+++ b/opentracing-api/src/main/java/io/opentracing/Tracer.java
@@ -207,7 +207,7 @@ public interface Tracer extends Closeable {
          * </ul>
          * ... then an inferred {@link References#CHILD_OF} reference is created to the
          * {@link ScopeManager#activeSpan()}'s {@link SpanContext} when either
-         * {@link SpanBuilder#start()} or {@link SpanBuilder#startActive} is invoked.
+         * {@link SpanBuilder#start()} is invoked.
 
          * @return the newly-started Span instance, which has *not* been automatically registered
          *         via the {@link ScopeManager}


### PR DESCRIPTION
The previously referred method was removed from the API, hence it no longer exists. Must say too that semantic versioning was used wrong! Removing this method was a breaking change. The same as removing `ScopeManager.activate(Span span, boolean finishSpanOnClose)`. Please be more careful with the versioning of the libs, deprecating a method is better than removing directly :)